### PR TITLE
BUGFIX: Added missing response cases

### DIFF
--- a/Examples/Scenes/SampleScene.unity
+++ b/Examples/Scenes/SampleScene.unity
@@ -834,6 +834,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _pluginName: ExamplePlugin
   _pluginAuthor: Skeletom
+  _pluginIcon: {fileID: 2800000, guid: 774c2806a6e98e74e93c0f98f34d9aa4, type: 3}
   _text: {fileID: 1652142700}
   _color: {r: 1, g: 0.6556604, b: 0.87041146, a: 1}
   _headRolling: 0

--- a/VTS/Models/JsonUtilityImpl.cs
+++ b/VTS/Models/JsonUtilityImpl.cs
@@ -8,7 +8,34 @@
 
         public string ToJson(object obj)
         {
-            return UnityEngine.JsonUtility.ToJson(obj);
+            string json = UnityEngine.JsonUtility.ToJson(obj);
+            return RemoveNullProps(json);
+        }
+
+        private string RemoveNullProps(string input){
+            string[] props = input.Split(',', '{', '}');
+            string output = input;
+            foreach(string prop in props){
+                // We're doing direct string manipulation on a serialized JSON, which is incredibly frail.
+                // Please forgive my sins, as Unity's builtin JSON tool uses default field values instead of nulls,
+                // and sometimes that is unacceptable behavior.
+                // I'd use a more robust JSON library if I wasn't publishing this as a plugin.
+                string[] pair = prop.Split(':');
+                if(pair.Length > 1){
+                    float nullable = 0.0f;
+                    float.TryParse(pair[1], out nullable);
+                    if(float.MinValue.Equals(nullable)){
+                        output = output.Replace(prop+",", "");
+                        output = output.Replace(prop, "");
+                    }
+                    else if("\"\"".Equals(pair[1])){
+                        output = output.Replace(prop+",", "");
+                        output = output.Replace(prop, "");
+                    }
+                }
+            }
+            output = output.Replace(",}", "}");
+            return output;
         }
     }
 }


### PR DESCRIPTION
This fix addresses: 

- Added response for `VTSHotkeyTriggerData`
- Added response case for `VTSParameterValueData`
- Moved null property removal to the JSON utility (formerly in the VTS Web Socket plugin)