### PR TITLE
BUGFIX: Non-blocking UDP and default float value change

### DIFF
--- a/Examples/Scripts/RefreshableDropdown.cs
+++ b/Examples/Scripts/RefreshableDropdown.cs
@@ -45,7 +45,6 @@ public abstract class RefreshableDropdown : MonoBehaviour
         int index = Mathf.Min(this._dropdown.options.Count, 
             StringToIndex(currentSelection));
         this._dropdown.SetValueWithoutNotify(index);
-        Debug.Log(index);
         this.SetValue(index);
     }
 

--- a/VTS/Models/JsonUtilityImpl.cs
+++ b/VTS/Models/JsonUtilityImpl.cs
@@ -24,7 +24,7 @@
                 if(pair.Length > 1){
                     float nullable = 0.0f;
                     float.TryParse(pair[1], out nullable);
-                    if(float.MinValue.Equals(nullable)){
+                    if("NaN".Equals(pair[1]) || float.MinValue.Equals(nullable)){
                         output = output.Replace(prop+",", "");
                         output = output.Replace(prop, "");
                     }

--- a/VTS/Models/VTSData.cs
+++ b/VTS/Models/VTSData.cs
@@ -111,10 +111,10 @@ namespace VTS.Models {
 
     [System.Serializable]
     public class ModelPosition{
-        public float positionX = float.MinValue;
-        public float positionY = float.MinValue;
-        public float rotation = float.MinValue;
-        public float size = float.MinValue;
+        public float positionX = float.NaN;
+        public float positionY = float.NaN;
+        public float rotation = float.NaN;
+        public float size = float.NaN;
 
     }
 
@@ -441,8 +441,8 @@ namespace VTS.Models {
     [System.Serializable]
     public class VTSParameterInjectionValue{
         public string id;
-        public float value = float.MinValue;
-        public float weight = float.MinValue;
+        public float value = float.NaN;
+        public float weight = float.NaN;
     }
 
     [System.Serializable]

--- a/VTS/Networking/VTSWebSocket.cs
+++ b/VTS/Networking/VTSWebSocket.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 
 using System.Text;
+using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 
@@ -70,7 +71,11 @@ namespace VTS.Networking {
         private void StartUDP(){
             try{
                 if(UDP_CLIENT == null){
-                    UDP_CLIENT = new UdpClient(47779);
+                    // This configuration should prevent the UDP client from blocking other connections to the port
+                    IPEndPoint LOCAL_PT = new IPEndPoint(IPAddress.Any, 47779);
+                    UDP_CLIENT = new UdpClient();
+                    UDP_CLIENT.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+                    UDP_CLIENT.Client.Bind(LOCAL_PT);
                 }
             }catch(Exception e){
                 Debug.LogError(e);


### PR DESCRIPTION
This bugfix includes:

- UPD port discovery client will no longer block other clients (thank you @xserp)!
- Default float values are now NaN instead of float.minValue.