### PR TITLE
Fix Typos

### DIFF
--- a/VTS/Models/VTSData.cs
+++ b/VTS/Models/VTSData.cs
@@ -97,7 +97,7 @@ namespace VTS.Models {
     [System.Serializable]
     public class VTSFolderInfoData : VTSMessageData {
          public VTSFolderInfoData(){
-            this.messageType = "VTSFolderInfoRequestuest";
+            this.messageType = "VTSFolderInfoRequest";
             this.data = new Data();
         }
         public Data data;
@@ -554,7 +554,7 @@ namespace VTS.Models {
 		    public int baseStrength;
 		    public int baseWind;
 		    public bool apiPhysicsOverrideActive;
-		    public string apiPhysicsOverridePluginNam;
+		    public string apiPhysicsOverridePluginName;
 		    public VTSPhysicsGroup[] physicsGroups;
         }
     }


### PR DESCRIPTION
Hi!

I noticed these two typos and figured I'd point them out. 

I didn't test the functionality, but It looks like this code should currently be broken and should be fixed with this change.
There are luckily 0 refs to `apiPhysicsOverridePluginNam` as well.

I did double check the API docs (https://github.com/DenchiSoft/VTubeStudio)

Typo 1 request doc:
`{
	"apiName": "VTubeStudioPublicAPI",
	"apiVersion": "1.0",
	"requestID": "SomeID",
	"messageType": "VTSFolderInfoRequest"
}`

Typo 2 response doc: 
`{
	"apiName": "VTubeStudioPublicAPI",
	"apiVersion": "1.0",
	"timestamp": 1625405710728,
	"requestID": "SomeID",
	"messageType": "GetCurrentModelPhysicsResponse",
	"data": {
		"modelLoaded": true,
		"modelName": "My Currently Loaded Model",
		"modelID": "UniqueIDOfModel",
		"modelHasPhysics": true,
		"physicsSwitchedOn": true,
		"usingLegacyPhysics": false,
		"physicsFPSSetting": -1,
		"baseStrength": 50,
		"baseWind": 17,
		"apiPhysicsOverrideActive": false,
		"apiPhysicsOverridePluginName": "",
		"physicsGroups": [
			{
				"groupID": "PhysicsSetting1",
				"groupName": "Hair Front Physics",
				"strengthMultiplier": 1.5,
				"windMultiplier": 0.3
			},
			{
				"groupID": "PhysicsSetting2",
				"groupName": "Clothes Physics",
				"strengthMultiplier": 1,
				"windMultiplier": 2
			}
		]
	}
}`

Hope this helps, thank you for working on this project! Let me know if you have any questions.