### PR TITLE
FIX: Misc Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# VTS-Sharp v2.0.0
+# VTS-Sharp v2.0.1
 A C# client interface for creating VTube Studio Plugins with the [official VTube Studio API](https://github.com/DenchiSoft/VTubeStudio), for use in Unity and other C# runtime environments!
 
 ## IMPORTANT! 

--- a/VTS/Core/Interfaces/IWebSocket.cs
+++ b/VTS/Core/Interfaces/IWebSocket.cs
@@ -43,9 +43,6 @@ namespace VTS.Core {
 		void Send(string message);
 		/// <summary>
 		/// Method that is called by the system once per tick, to process incoming events.
-		/// 
-		//	For systems like Unity, which can only do most tasks on the main thread, 
-		/// this method will be invoked via a poller in the Update MonoBehaviour lifecycle method.
 		/// </summary>
 		/// <param name="timeDelta">The time since the last update tick, in seconds.</param>
 		void Tick(float timeDelta);

--- a/VTS/Core/Models/VTSData.cs
+++ b/VTS/Core/Models/VTSData.cs
@@ -267,25 +267,6 @@ namespace VTS.Core {
 		public byte colorG;
 		public byte colorB;
 		public byte colorA;
-
-		/// <summary>
-		/// Converts the color into a Unity color struct.
-		/// </summary>
-		/// <returns></returns>
-		public UnityEngine.Color32 ToColor32() {
-			return new UnityEngine.Color32(colorR, colorG, colorB, colorA);
-		}
-
-		/// <summary>
-		/// Loads color data from a Unity color struct
-		/// </summary>
-		/// <param name="color"></param>
-		public void FromColor32(UnityEngine.Color32 color) {
-			this.colorA = color.a;
-			this.colorB = color.b;
-			this.colorG = color.g;
-			this.colorR = color.r;
-		}
 	}
 
 	[System.Serializable]

--- a/VTS/Unity/UnityVTSPlugin.cs
+++ b/VTS/Unity/UnityVTSPlugin.cs
@@ -329,7 +329,12 @@ namespace VTS.Unity {
 		/// <param name="color">The color to convert</param>
 		/// <returns></returns>
 		public static Color32 ColorTintToColor(ColorTint color) {
-			return new Color32(color.colorR, color.colorG, color.colorB, color.colorA);
+			return new Color32(
+				color.colorR, 
+				color.colorG, 
+				color.colorB, 
+				color.colorA
+			);
 		}
 
 		/// <summary>


### PR DESCRIPTION
This patch fixes:

* Unity Color conversion helper method being present in Core library (this method now exists in the UnityVTSPlugin class)
* `PluginAuthor` accessor mistakenly pointing to the `PluginName` string in the CoreVTSPlugin implementation.

Thank you to @Ryokune for catching both of these mistakes!