### PR TITLE
async/await Pattern + WebSockets with .NET Core Support + Non-Unity Example

### DIFF
--- a/Examples/NonUnity/MyFirstPlugin.cs
+++ b/Examples/NonUnity/MyFirstPlugin.cs
@@ -1,0 +1,27 @@
+﻿using VTS.Core;
+
+namespace VTS.NonUnity;
+
+public static class MyFirstPlugin
+{
+    public static async Task Main(string[] args)
+    {
+        var logger = new ConsoleVTSLoggerImpl();
+        var websocket = new WebSocketNetCoreImpl(logger);
+        var jsonUtility = new NewtonsoftJsonUtilityImpl();
+        var tokenStorage = new TokenStorageImpl("");
+
+        var plugin = new CoreVTSPlugin(logger, 100, "My first plugin", "My Name", "");
+
+        try
+        {
+            await plugin.InitializeAsync(websocket, jsonUtility, tokenStorage, () => logger.LogWarning("Disconnected!"));
+
+            logger.Log("Connected!");
+        }
+        catch (VTSException e)
+        {
+            logger.LogError(e);
+        }
+    }
+}

--- a/Examples/NonUnity/MyFirstPlugin.cs
+++ b/Examples/NonUnity/MyFirstPlugin.cs
@@ -1,27 +1,29 @@
-﻿using VTS.Core;
+﻿using System.Threading.Tasks;
+using VTS.Core;
 
-namespace VTS.NonUnity;
-
-public static class MyFirstPlugin
+namespace VTS.NonUnity
 {
-    public static async Task Main(string[] args)
+    public static class MyFirstPlugin
     {
-        var logger = new ConsoleVTSLoggerImpl();
-        var websocket = new WebSocketNetCoreImpl(logger);
-        var jsonUtility = new NewtonsoftJsonUtilityImpl();
-        var tokenStorage = new TokenStorageImpl("");
-
-        var plugin = new CoreVTSPlugin(logger, 100, "My first plugin", "My Name", "");
-
-        try
+        public static async Task Main(string[] args)
         {
-            await plugin.InitializeAsync(websocket, jsonUtility, tokenStorage, () => logger.LogWarning("Disconnected!"));
+            var logger = new ConsoleVTSLoggerImpl();
+            var websocket = new WebSocketNetCoreImpl(logger);
+            var jsonUtility = new NewtonsoftJsonUtilityImpl();
+            var tokenStorage = new TokenStorageImpl("");
 
-            logger.Log("Connected!");
-        }
-        catch (VTSException e)
-        {
-            logger.LogError(e);
+            var plugin = new CoreVTSPlugin(logger, 100, "My first plugin", "My Name", "");
+
+            try
+            {
+                await plugin.InitializeAsync(websocket, jsonUtility, tokenStorage, () => logger.LogWarning("Disconnected!"));
+
+                logger.Log("Connected!");
+            }
+            catch (VTSException e)
+            {
+                logger.LogError(e);
+            }
         }
     }
 }

--- a/Examples/NonUnity/MyFirstPlugin.cs
+++ b/Examples/NonUnity/MyFirstPlugin.cs
@@ -17,8 +17,13 @@ namespace VTS.NonUnity
             try
             {
                 await plugin.InitializeAsync(websocket, jsonUtility, tokenStorage, () => logger.LogWarning("Disconnected!"));
-
                 logger.Log("Connected!");
+
+                var apiState = await plugin.GetAPIStateAsync();
+                logger.Log("Using VTubeStudio " + apiState.data.vTubeStudioVersion);
+                
+                var currentModel = await plugin.GetCurrentModelAsync();
+                logger.Log("The current model is: " + currentModel.data.modelName);
             }
             catch (VTSException e)
             {

--- a/VTS/Core/CoreVTSPlugin.cs
+++ b/VTS/Core/CoreVTSPlugin.cs
@@ -103,7 +103,7 @@ namespace VTS.Core {
 
 		public Task InitializeAsync(IWebSocket webSocket, IJsonUtility jsonUtility, ITokenStorage tokenStorage, Action onDisconnect)
 		{
-			var tcs = new TaskCompletionSource<object?>();
+			var tcs = new TaskCompletionSource<object>();
 
 			Initialize(
 				webSocket,

--- a/VTS/Core/CoreVTSPlugin.cs
+++ b/VTS/Core/CoreVTSPlugin.cs
@@ -46,7 +46,7 @@ namespace VTS.Core {
 			this._tickInterval = updateIntervalMs;
 			this._tickLoop = TickLoop(this._cancelToken.Token);
 
-			if (pluginName.Length is < 3 or > 32 || pluginAuthor.Length is < 3 or > 32)
+			if (pluginName.Length < 3 || pluginName.Length > 32 || pluginAuthor.Length < 3 || pluginAuthor.Length > 32)
 				throw new Exception("Plugin name and plugin author must both be between 3 and 32 characters.");
 		}
 
@@ -103,13 +103,13 @@ namespace VTS.Core {
 
 		public Task InitializeAsync(IWebSocket webSocket, IJsonUtility jsonUtility, ITokenStorage tokenStorage, Action onDisconnect)
 		{
-			var tcs = new TaskCompletionSource();
+			var tcs = new TaskCompletionSource<object?>();
 
 			Initialize(
 				webSocket,
 				jsonUtility,
 				tokenStorage,
-				() => tcs.SetResult(),
+				() => tcs.SetResult(null),
 				onDisconnect,
 				error => tcs.SetException(error.ToException())
 			);

--- a/VTS/Core/Implementations/WebSocketNetCore/WebSocketNetCoreImpl.cs
+++ b/VTS/Core/Implementations/WebSocketNetCore/WebSocketNetCoreImpl.cs
@@ -1,0 +1,193 @@
+﻿using System.Collections.Concurrent;
+using System.Text;
+using System.Net.WebSockets;
+
+namespace VTS.Core {
+
+	public class WebSocketNetCoreImpl : IWebSocket {
+		private static readonly UTF8Encoding Encoder = new();
+
+		private ClientWebSocket? _socket;
+		private readonly ConcurrentQueue<string> _intakeQueue;
+		private readonly ConcurrentQueue<Action> _responseQueue;
+		private bool _attemptReconnect;
+
+		private Action _onConnect = () => { };
+		private Action _onDisconnect = () => { };
+		private Action<Exception> _onError = (e) => { };
+		
+		private string _url = "";
+		private readonly IVTSLogger _logger;
+
+		public WebSocketNetCoreImpl(IVTSLogger logger) {
+			_logger = logger;
+			_intakeQueue = new ConcurrentQueue<string>();
+			_responseQueue = new ConcurrentQueue<Action>();
+		}
+
+		public string GetNextResponse() {
+			_intakeQueue.TryDequeue(out var response);
+			return response!;
+		}
+
+		public bool IsConnecting() {
+			return _socket is { State: WebSocketState.Connecting };
+		}
+
+		public bool IsConnectionOpen() {
+			return _socket is { State: WebSocketState.Open };
+		}
+
+		public void Send(string message) {
+			var buffer = Encoder.GetBytes(message);
+			_socket?.SendAsync(new ReadOnlyMemory<byte>(buffer), WebSocketMessageType.Text, WebSocketMessageFlags.EndOfMessage, default)
+				.ConfigureAwait(false)
+				.GetAwaiter()
+				.GetResult();
+		}
+
+		public void Start(string url, Action onConnect, Action onDisconnect, Action<Exception> onError) {
+			_url = url;
+			_socket = new ClientWebSocket();
+			_logger.Log($"Attempting to connect to {_url}");
+			_socket.Options.KeepAliveInterval = TimeSpan.FromSeconds(10);
+			_onConnect = onConnect;
+			_onDisconnect = onDisconnect;
+			_onError = onError;
+
+			Task.Run<Task>(async () =>
+			{
+				try
+				{
+					await _socket.ConnectAsync(new Uri(_url), CancellationToken.None);
+				}
+				catch (Exception e)
+				{
+					_responseQueue.Enqueue(() => {
+						_logger.LogError($"[{_url}] - Socket error...");
+						_logger.LogError($"'{e.Message}', {e}");
+						_onError(e);
+					});
+					return;
+				}
+				
+				_responseQueue.Enqueue(() => {
+					_onConnect();
+					_logger.Log($"[{_url}] - Socket open!");
+					_attemptReconnect = true;
+				});
+
+				while (true)
+				{
+					var result = await _socket.ReceiveAsync(CancellationToken.None);
+					if(result.closeStatus == null)
+					{
+						_responseQueue.Enqueue(() =>
+						{
+							if (result is { buffer: not null, messageType: WebSocketMessageType.Text })
+							{
+								_intakeQueue.Enqueue(Encoder.GetString(result.buffer));
+							}
+						});
+					}
+					else
+					{
+						_responseQueue.Enqueue(() => {
+							var msg =
+								$"[{_url}] - Socket closing: {result.closeStatus}, '{result.closeStatusDescription}', {result.closeStatus == WebSocketCloseStatus.NormalClosure}";
+							if (result.closeStatus == WebSocketCloseStatus.NormalClosure) {
+								_logger.Log(msg);
+								_onDisconnect();
+							}
+							else {
+								_logger.LogError(msg);
+								_onError(new Exception(msg));
+								if (_attemptReconnect) {
+									Reconnect();
+								}
+							}
+						});
+					}
+				}
+
+			}, CancellationToken.None);
+			
+		}
+
+		public void Stop() {
+			_attemptReconnect = false;
+			if (_socket is { State: WebSocketState.Open }) {
+				_socket.Abort();
+			}
+		}
+
+		private void Reconnect() {
+			Start(_url, _onConnect, _onDisconnect, _onError);
+		}
+
+		public void Tick(float timeDelta) {
+			do {
+				if (_responseQueue.IsEmpty || !_responseQueue.TryDequeue(out var action))
+					continue;
+				
+				try {
+					action();
+				}
+				catch (Exception e) {
+					_logger.LogError($"Socket error: {e.StackTrace}");
+				}
+
+			} while (!_responseQueue.IsEmpty);
+		}
+	}
+}
+
+
+internal static class WebSocketExtensions
+{
+	public static async Task<(
+		byte[] buffer,
+		WebSocketMessageType messageType,
+		WebSocketCloseStatus? closeStatus,
+		string? closeStatusDescription
+		)> ReceiveAsync(this ClientWebSocket client, CancellationToken cancellationToken)
+	{
+		const int maxFrameSize = 1024 * 1024 * 10; // 10 MB
+		const int bufferSize = 1024; // 1 KB
+		var buffer = new byte[bufferSize];
+		var offset = 0;
+		var free = buffer.Length;
+		
+		while (true)
+		{
+			var result = await client.ReceiveAsync(new ArraySegment<byte>(buffer, offset, free), cancellationToken);
+			offset += result.Count;
+			free -= result.Count;
+			
+			if (result.EndOfMessage || result.CloseStatus != null)
+			{
+				return (buffer, result.MessageType, result.CloseStatus, result.CloseStatusDescription);
+			}
+			
+			if (free == 0)
+			{
+				// No free space
+				// Resize the outgoing buffer
+				var newSize = buffer.Length + bufferSize;
+				
+				// Check if the new size exceeds a limit
+				// It should suit the data it receives
+				// This limit however has a max value of 2 billion bytes (2 GB)
+				if (newSize > maxFrameSize)
+				{
+					throw new Exception ("Maximum size exceeded");
+				}
+				
+				var newBuffer = new byte[newSize];
+				Array.Copy(buffer, 0, newBuffer, 0, offset);
+				buffer = newBuffer;
+				free = buffer.Length - offset;
+			}
+		}
+	}
+}

--- a/VTS/Core/Implementations/WebSocketNetCore/WebSocketNetCoreImpl.cs
+++ b/VTS/Core/Implementations/WebSocketNetCore/WebSocketNetCoreImpl.cs
@@ -1,193 +1,213 @@
-﻿using System.Collections.Concurrent;
-using System.Text;
+﻿using System;
+using System.Collections.Concurrent;
 using System.Net.WebSockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
-namespace VTS.Core {
+namespace VTS.Core
+{
+    public class WebSocketNetCoreImpl : IWebSocket
+    {
+        private static readonly UTF8Encoding Encoder = new UTF8Encoding();
 
-	public class WebSocketNetCoreImpl : IWebSocket {
-		private static readonly UTF8Encoding Encoder = new();
+        private ClientWebSocket? _socket;
+        private readonly ConcurrentQueue<string> _intakeQueue;
+        private readonly ConcurrentQueue<Action> _responseQueue;
+        private bool _attemptReconnect;
 
-		private ClientWebSocket? _socket;
-		private readonly ConcurrentQueue<string> _intakeQueue;
-		private readonly ConcurrentQueue<Action> _responseQueue;
-		private bool _attemptReconnect;
+        private Action _onConnect = () => { };
+        private Action _onDisconnect = () => { };
+        private Action<Exception> _onError = (e) => { };
 
-		private Action _onConnect = () => { };
-		private Action _onDisconnect = () => { };
-		private Action<Exception> _onError = (e) => { };
-		
-		private string _url = "";
-		private readonly IVTSLogger _logger;
+        private string _url = "";
+        private readonly IVTSLogger _logger;
 
-		public WebSocketNetCoreImpl(IVTSLogger logger) {
-			_logger = logger;
-			_intakeQueue = new ConcurrentQueue<string>();
-			_responseQueue = new ConcurrentQueue<Action>();
-		}
+        public WebSocketNetCoreImpl(IVTSLogger logger)
+        {
+            _logger = logger;
+            _intakeQueue = new ConcurrentQueue<string>();
+            _responseQueue = new ConcurrentQueue<Action>();
+        }
 
-		public string GetNextResponse() {
-			_intakeQueue.TryDequeue(out var response);
-			return response!;
-		}
+        public string GetNextResponse()
+        {
+            _intakeQueue.TryDequeue(out var response);
+            return response!;
+        }
 
-		public bool IsConnecting() {
-			return _socket is { State: WebSocketState.Connecting };
-		}
+        public bool IsConnecting()
+        {
+            return _socket is { State: WebSocketState.Connecting };
+        }
 
-		public bool IsConnectionOpen() {
-			return _socket is { State: WebSocketState.Open };
-		}
+        public bool IsConnectionOpen()
+        {
+            return _socket is { State: WebSocketState.Open };
+        }
 
-		public void Send(string message) {
-			var buffer = Encoder.GetBytes(message);
-			_socket?.SendAsync(new ReadOnlyMemory<byte>(buffer), WebSocketMessageType.Text, WebSocketMessageFlags.EndOfMessage, default)
-				.ConfigureAwait(false)
-				.GetAwaiter()
-				.GetResult();
-		}
+        public void Send(string message)
+        {
+            var buffer = Encoder.GetBytes(message);
+            _socket?.SendAsync(new ReadOnlyMemory<byte>(buffer), WebSocketMessageType.Text, true, default)
+                .ConfigureAwait(false)
+                .GetAwaiter()
+                .GetResult();
+        }
 
-		public void Start(string url, Action onConnect, Action onDisconnect, Action<Exception> onError) {
-			_url = url;
-			_socket = new ClientWebSocket();
-			_logger.Log($"Attempting to connect to {_url}");
-			_socket.Options.KeepAliveInterval = TimeSpan.FromSeconds(10);
-			_onConnect = onConnect;
-			_onDisconnect = onDisconnect;
-			_onError = onError;
+        public void Start(string url, Action onConnect, Action onDisconnect, Action<Exception> onError)
+        {
+            _url = url;
+            _socket = new ClientWebSocket();
+            _logger.Log($"Attempting to connect to {_url}");
+            _socket.Options.KeepAliveInterval = TimeSpan.FromSeconds(10);
+            _onConnect = onConnect;
+            _onDisconnect = onDisconnect;
+            _onError = onError;
 
-			Task.Run<Task>(async () =>
-			{
-				try
-				{
-					await _socket.ConnectAsync(new Uri(_url), CancellationToken.None);
-				}
-				catch (Exception e)
-				{
-					_responseQueue.Enqueue(() => {
-						_logger.LogError($"[{_url}] - Socket error...");
-						_logger.LogError($"'{e.Message}', {e}");
-						_onError(e);
-					});
-					return;
-				}
-				
-				_responseQueue.Enqueue(() => {
-					_onConnect();
-					_logger.Log($"[{_url}] - Socket open!");
-					_attemptReconnect = true;
-				});
+            Task.Run<Task>(async () =>
+            {
+                try
+                {
+                    await _socket.ConnectAsync(new Uri(_url), CancellationToken.None);
+                }
+                catch (Exception e)
+                {
+                    _responseQueue.Enqueue(() =>
+                    {
+                        _logger.LogError($"[{_url}] - Socket error...");
+                        _logger.LogError($"'{e.Message}', {e}");
+                        _onError(e);
+                    });
+                    return;
+                }
 
-				while (true)
-				{
-					var result = await _socket.ReceiveAsync(CancellationToken.None);
-					if(result.closeStatus == null)
-					{
-						_responseQueue.Enqueue(() =>
-						{
-							if (result is { buffer: not null, messageType: WebSocketMessageType.Text })
-							{
-								_intakeQueue.Enqueue(Encoder.GetString(result.buffer));
-							}
-						});
-					}
-					else
-					{
-						_responseQueue.Enqueue(() => {
-							var msg =
-								$"[{_url}] - Socket closing: {result.closeStatus}, '{result.closeStatusDescription}', {result.closeStatus == WebSocketCloseStatus.NormalClosure}";
-							if (result.closeStatus == WebSocketCloseStatus.NormalClosure) {
-								_logger.Log(msg);
-								_onDisconnect();
-							}
-							else {
-								_logger.LogError(msg);
-								_onError(new Exception(msg));
-								if (_attemptReconnect) {
-									Reconnect();
-								}
-							}
-						});
-					}
-				}
+                _responseQueue.Enqueue(() =>
+                {
+                    _onConnect();
+                    _logger.Log($"[{_url}] - Socket open!");
+                    _attemptReconnect = true;
+                });
 
-			}, CancellationToken.None);
-			
-		}
+                while (true)
+                {
+                    var result = await _socket.ReceiveAsync(CancellationToken.None);
+                    if (result.closeStatus == null)
+                    {
+                        _responseQueue.Enqueue(() =>
+                        {
+                            if (result is { buffer: { }, messageType: WebSocketMessageType.Text })
+                            {
+                                _intakeQueue.Enqueue(Encoder.GetString(result.buffer));
+                            }
+                        });
+                    }
+                    else
+                    {
+                        _responseQueue.Enqueue(() =>
+                        {
+                            var msg =
+                                $"[{_url}] - Socket closing: {result.closeStatus}, '{result.closeStatusDescription}', {result.closeStatus == WebSocketCloseStatus.NormalClosure}";
+                            if (result.closeStatus == WebSocketCloseStatus.NormalClosure)
+                            {
+                                _logger.Log(msg);
+                                _onDisconnect();
+                            }
+                            else
+                            {
+                                _logger.LogError(msg);
+                                _onError(new Exception(msg));
+                                if (_attemptReconnect)
+                                {
+                                    Reconnect();
+                                }
+                            }
+                        });
+                    }
+                }
+            }, CancellationToken.None);
+        }
 
-		public void Stop() {
-			_attemptReconnect = false;
-			if (_socket is { State: WebSocketState.Open }) {
-				_socket.Abort();
-			}
-		}
+        public void Stop()
+        {
+            _attemptReconnect = false;
+            if (_socket is { State: WebSocketState.Open })
+            {
+                _socket.Abort();
+            }
+        }
 
-		private void Reconnect() {
-			Start(_url, _onConnect, _onDisconnect, _onError);
-		}
+        private void Reconnect()
+        {
+            Start(_url, _onConnect, _onDisconnect, _onError);
+        }
 
-		public void Tick(float timeDelta) {
-			do {
-				if (_responseQueue.IsEmpty || !_responseQueue.TryDequeue(out var action))
-					continue;
-				
-				try {
-					action();
-				}
-				catch (Exception e) {
-					_logger.LogError($"Socket error: {e.StackTrace}");
-				}
+        public void Tick(float timeDelta)
+        {
+            do
+            {
+                if (_responseQueue.IsEmpty || !_responseQueue.TryDequeue(out var action))
+                    continue;
 
-			} while (!_responseQueue.IsEmpty);
-		}
-	}
+                try
+                {
+                    action();
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError($"Socket error: {e.StackTrace}");
+                }
+            } while (!_responseQueue.IsEmpty);
+        }
+    }
 }
 
 
 internal static class WebSocketExtensions
 {
-	public static async Task<(
-		byte[] buffer,
-		WebSocketMessageType messageType,
-		WebSocketCloseStatus? closeStatus,
-		string? closeStatusDescription
-		)> ReceiveAsync(this ClientWebSocket client, CancellationToken cancellationToken)
-	{
-		const int maxFrameSize = 1024 * 1024 * 10; // 10 MB
-		const int bufferSize = 1024; // 1 KB
-		var buffer = new byte[bufferSize];
-		var offset = 0;
-		var free = buffer.Length;
-		
-		while (true)
-		{
-			var result = await client.ReceiveAsync(new ArraySegment<byte>(buffer, offset, free), cancellationToken);
-			offset += result.Count;
-			free -= result.Count;
-			
-			if (result.EndOfMessage || result.CloseStatus != null)
-			{
-				return (buffer, result.MessageType, result.CloseStatus, result.CloseStatusDescription);
-			}
-			
-			if (free == 0)
-			{
-				// No free space
-				// Resize the outgoing buffer
-				var newSize = buffer.Length + bufferSize;
-				
-				// Check if the new size exceeds a limit
-				// It should suit the data it receives
-				// This limit however has a max value of 2 billion bytes (2 GB)
-				if (newSize > maxFrameSize)
-				{
-					throw new Exception ("Maximum size exceeded");
-				}
-				
-				var newBuffer = new byte[newSize];
-				Array.Copy(buffer, 0, newBuffer, 0, offset);
-				buffer = newBuffer;
-				free = buffer.Length - offset;
-			}
-		}
-	}
+    public static async Task<(
+        byte[] buffer,
+        WebSocketMessageType messageType,
+        WebSocketCloseStatus? closeStatus,
+        string? closeStatusDescription
+        )> ReceiveAsync(this ClientWebSocket client, CancellationToken cancellationToken)
+    {
+        const int maxFrameSize = 1024 * 1024 * 10; // 10 MB
+        const int bufferSize = 1024; // 1 KB
+        var buffer = new byte[bufferSize];
+        var offset = 0;
+        var free = buffer.Length;
+
+        while (true)
+        {
+            var result = await client.ReceiveAsync(new ArraySegment<byte>(buffer, offset, free), cancellationToken);
+            offset += result.Count;
+            free -= result.Count;
+
+            if (result.EndOfMessage || result.CloseStatus != null)
+            {
+                return (buffer, result.MessageType, result.CloseStatus, result.CloseStatusDescription);
+            }
+
+            if (free == 0)
+            {
+                // No free space
+                // Resize the outgoing buffer
+                var newSize = buffer.Length + bufferSize;
+
+                // Check if the new size exceeds a limit
+                // It should suit the data it receives
+                // This limit however has a max value of 2 billion bytes (2 GB)
+                if (newSize > maxFrameSize)
+                {
+                    throw new Exception("Maximum size exceeded");
+                }
+
+                var newBuffer = new byte[newSize];
+                Array.Copy(buffer, 0, newBuffer, 0, offset);
+                buffer = newBuffer;
+                free = buffer.Length - offset;
+            }
+        }
+    }
 }

--- a/VTS/Core/Models/VTSData.cs
+++ b/VTS/Core/Models/VTSData.cs
@@ -29,6 +29,20 @@ namespace VTS.Core {
 	}
 
 	[System.Serializable]
+	public class VTSException : Exception
+	{
+		public VTSErrorData ErrorData { get; }
+
+		public VTSException(VTSErrorData errorData)
+			: base($"Request ID #{errorData.requestID} failed\n" 
+			       + $"ErrorID - {errorData.data.errorID}\n" 
+			       + $"Message - {errorData.data.message}")
+		{
+			ErrorData = errorData;
+		}
+	}
+
+	[System.Serializable]
 	public struct Pair {
 		public float x;
 		public float y;

--- a/VTS/Core/VTSExtensions.cs
+++ b/VTS/Core/VTSExtensions.cs
@@ -1,0 +1,88 @@
+namespace VTS.Core;
+
+internal static class VTSExtensions
+{
+    internal static VTSException ToException(this VTSErrorData errorData)
+    {
+        return new VTSException(errorData);
+    }
+
+    internal static Task<TSuccess> Async<TSuccess, TError>(this Action<Action<TSuccess>, Action<TError>> action)
+        where TError : VTSErrorData
+    {
+        var tcs = new TaskCompletionSource<TSuccess>();
+
+        action(
+            modelData => tcs.SetResult(modelData),
+            errorData => tcs.SetException(errorData.ToException())
+        );
+
+        return tcs.Task;
+    }
+
+    internal static Task<TSuccess> Async<T1, TSuccess, TError>(this Action<T1, Action<TSuccess>, Action<TError>> action,
+        T1 argument1) where TError : VTSErrorData
+    {
+        var tcs = new TaskCompletionSource<TSuccess>();
+
+        action(
+            argument1,
+            modelData => tcs.SetResult(modelData),
+            errorData => tcs.SetException(errorData.ToException())
+        );
+
+        return tcs.Task;
+    }
+
+    internal static Task<TSuccess> Async<T1, T2, TSuccess, TError>(
+        this Action<T1, T2, Action<TSuccess>, Action<TError>> action, T1 argument1, T2 argument2)
+        where TError : VTSErrorData
+    {
+        var tcs = new TaskCompletionSource<TSuccess>();
+
+        action(
+            argument1,
+            argument2,
+            modelData => tcs.SetResult(modelData),
+            errorData => tcs.SetException(errorData.ToException())
+        );
+
+        return tcs.Task;
+    }
+
+    internal static Task<TSuccess> Async<T1, T2, T3, TSuccess, TError>(
+        this Action<T1, T2, T3, Action<TSuccess>, Action<TError>> action, T1 argument1, T2 argument2, T3 argument3)
+        where TError : VTSErrorData
+    {
+        var tcs = new TaskCompletionSource<TSuccess>();
+
+        action(
+            argument1,
+            argument2,
+            argument3,
+            modelData => tcs.SetResult(modelData),
+            errorData => tcs.SetException(errorData.ToException())
+        );
+
+        return tcs.Task;
+    }
+
+    internal static Task<TSuccess> Async<T1, T2, T3, T4, TSuccess, TError>(
+        this Action<T1, T2, T3, T4, Action<TSuccess>, Action<TError>> action, T1 argument1, T2 argument2, T3 argument3,
+        T4 argument4) where TError : VTSErrorData
+    {
+        var tcs = new TaskCompletionSource<TSuccess>();
+
+        action(
+            argument1,
+            argument2,
+            argument3,
+            argument4,
+            modelData => tcs.SetResult(modelData),
+            errorData => tcs.SetException(errorData.ToException())
+        );
+
+        return tcs.Task;
+    }
+}
+

--- a/VTS/Core/VTSExtensions.cs
+++ b/VTS/Core/VTSExtensions.cs
@@ -1,88 +1,92 @@
-namespace VTS.Core;
+using System;
+using System.Threading.Tasks;
 
-internal static class VTSExtensions
+namespace VTS.Core
 {
-    internal static VTSException ToException(this VTSErrorData errorData)
+    internal static class VTSExtensions
     {
-        return new VTSException(errorData);
-    }
+        internal static VTSException ToException(this VTSErrorData errorData)
+        {
+            return new VTSException(errorData);
+        }
 
-    internal static Task<TSuccess> Async<TSuccess, TError>(this Action<Action<TSuccess>, Action<TError>> action)
-        where TError : VTSErrorData
-    {
-        var tcs = new TaskCompletionSource<TSuccess>();
+        internal static Task<TSuccess> Async<TSuccess, TError>(this Action<Action<TSuccess>, Action<TError>> action)
+            where TError : VTSErrorData
+        {
+            var tcs = new TaskCompletionSource<TSuccess>();
 
-        action(
-            modelData => tcs.SetResult(modelData),
-            errorData => tcs.SetException(errorData.ToException())
-        );
+            action(
+                modelData => tcs.SetResult(modelData),
+                errorData => tcs.SetException(errorData.ToException())
+            );
 
-        return tcs.Task;
-    }
+            return tcs.Task;
+        }
 
-    internal static Task<TSuccess> Async<T1, TSuccess, TError>(this Action<T1, Action<TSuccess>, Action<TError>> action,
-        T1 argument1) where TError : VTSErrorData
-    {
-        var tcs = new TaskCompletionSource<TSuccess>();
+        internal static Task<TSuccess> Async<T1, TSuccess, TError>(this Action<T1, Action<TSuccess>, Action<TError>> action,
+            T1 argument1) where TError : VTSErrorData
+        {
+            var tcs = new TaskCompletionSource<TSuccess>();
 
-        action(
-            argument1,
-            modelData => tcs.SetResult(modelData),
-            errorData => tcs.SetException(errorData.ToException())
-        );
+            action(
+                argument1,
+                modelData => tcs.SetResult(modelData),
+                errorData => tcs.SetException(errorData.ToException())
+            );
 
-        return tcs.Task;
-    }
+            return tcs.Task;
+        }
 
-    internal static Task<TSuccess> Async<T1, T2, TSuccess, TError>(
-        this Action<T1, T2, Action<TSuccess>, Action<TError>> action, T1 argument1, T2 argument2)
-        where TError : VTSErrorData
-    {
-        var tcs = new TaskCompletionSource<TSuccess>();
+        internal static Task<TSuccess> Async<T1, T2, TSuccess, TError>(
+            this Action<T1, T2, Action<TSuccess>, Action<TError>> action, T1 argument1, T2 argument2)
+            where TError : VTSErrorData
+        {
+            var tcs = new TaskCompletionSource<TSuccess>();
 
-        action(
-            argument1,
-            argument2,
-            modelData => tcs.SetResult(modelData),
-            errorData => tcs.SetException(errorData.ToException())
-        );
+            action(
+                argument1,
+                argument2,
+                modelData => tcs.SetResult(modelData),
+                errorData => tcs.SetException(errorData.ToException())
+            );
 
-        return tcs.Task;
-    }
+            return tcs.Task;
+        }
 
-    internal static Task<TSuccess> Async<T1, T2, T3, TSuccess, TError>(
-        this Action<T1, T2, T3, Action<TSuccess>, Action<TError>> action, T1 argument1, T2 argument2, T3 argument3)
-        where TError : VTSErrorData
-    {
-        var tcs = new TaskCompletionSource<TSuccess>();
+        internal static Task<TSuccess> Async<T1, T2, T3, TSuccess, TError>(
+            this Action<T1, T2, T3, Action<TSuccess>, Action<TError>> action, T1 argument1, T2 argument2, T3 argument3)
+            where TError : VTSErrorData
+        {
+            var tcs = new TaskCompletionSource<TSuccess>();
 
-        action(
-            argument1,
-            argument2,
-            argument3,
-            modelData => tcs.SetResult(modelData),
-            errorData => tcs.SetException(errorData.ToException())
-        );
+            action(
+                argument1,
+                argument2,
+                argument3,
+                modelData => tcs.SetResult(modelData),
+                errorData => tcs.SetException(errorData.ToException())
+            );
 
-        return tcs.Task;
-    }
+            return tcs.Task;
+        }
 
-    internal static Task<TSuccess> Async<T1, T2, T3, T4, TSuccess, TError>(
-        this Action<T1, T2, T3, T4, Action<TSuccess>, Action<TError>> action, T1 argument1, T2 argument2, T3 argument3,
-        T4 argument4) where TError : VTSErrorData
-    {
-        var tcs = new TaskCompletionSource<TSuccess>();
+        internal static Task<TSuccess> Async<T1, T2, T3, T4, TSuccess, TError>(
+            this Action<T1, T2, T3, T4, Action<TSuccess>, Action<TError>> action, T1 argument1, T2 argument2, T3 argument3,
+            T4 argument4) where TError : VTSErrorData
+        {
+            var tcs = new TaskCompletionSource<TSuccess>();
 
-        action(
-            argument1,
-            argument2,
-            argument3,
-            argument4,
-            modelData => tcs.SetResult(modelData),
-            errorData => tcs.SetException(errorData.ToException())
-        );
+            action(
+                argument1,
+                argument2,
+                argument3,
+                argument4,
+                modelData => tcs.SetResult(modelData),
+                errorData => tcs.SetException(errorData.ToException())
+            );
 
-        return tcs.Task;
+            return tcs.Task;
+        }
     }
 }
 


### PR DESCRIPTION
As I was trying to use this in a project outside of Unity, I met a few "inconveniences":
- The callback pattern that is used in this project is not something that is commonly used in modern .NET projects.
- The WebSocketSharp implementation is not compatible with any .NET version including and above .NET Core 1.0 (released in 2016)
- There is no example Plugin for non-Unity projects


### This PR introduces following changes:
- Adding support for `async/await` in all public asynchronous methods and functions (additionally to the callback pattern, so not breaking anything)
  - Example (callback pattern): `plugin.GetCurrentModel(result => onSuccessFunc(result), error => onErrorFunc(error))`
  - Example (async/await pattern): `var result = await plugin.GetCurrentModel();`
- Adding a native .NET WebSocket implementation with support for .NET Core / .NET 5 / .NET 6 / .NET 7 without introducing any new dependencies
- Adding an example MyFirstPlugin for non-Unity projects


**Disclaimer: I haven't tested this with Unity. Only outside of Unity.**
At least I made sure the changes are compatible with .NET Standard 2.1, as that is what Unity recommends.

Let me know if theres anything you'd like me to change.