### PR TITLE
Add NuGet packaging

### DIFF
--- a/NuGet~/.gitignore
+++ b/NuGet~/.gitignore
@@ -1,0 +1,6 @@
+bin/
+obj/
+/packages/
+riderModule.iml
+/_ReSharper.Caches/
+.idea

--- a/NuGet~/README.md
+++ b/NuGet~/README.md
@@ -11,4 +11,4 @@ See: https://docs.unity3d.com/Manual/SpecialFolders.html
 1. Open VTS-Sharp.sln in an IDE of your choice
 2. Build the project
 3. A NuGet package (VTS-Sharp.*.nupkg) will be generated inside [bin/Debug](bin/Debug).
-4. Upload it on https://www.nuget.org/
+4. Upload it on https://www.nuget.org/packages/manage/upload

--- a/NuGet~/README.md
+++ b/NuGet~/README.md
@@ -9,7 +9,7 @@ See: https://docs.unity3d.com/Manual/SpecialFolders.html
 
 ### How to publish a NuGet package
 1. Open VTS-Sharp.sln in an IDE of your choice
-2. Set the version inside VTS.csproj
+2. Update the version number inside VTS.csproj
 3. Build the project
 4. A NuGet package (VTS-Sharp.*.nupkg) will be generated inside [bin/Debug](bin/Debug).
 5. Upload it on https://www.nuget.org/packages/manage/upload

--- a/NuGet~/README.md
+++ b/NuGet~/README.md
@@ -1,0 +1,14 @@
+﻿## Developer documentation
+
+### Important: Regarding the name of the directory: `NuGet~`
+
+This directory must either start with `.` or end with `~` in order for Unity to ignore it.
+Otherwise, Unity will print a lot of errors.
+
+See: https://docs.unity3d.com/Manual/SpecialFolders.html
+
+### How to publish a NuGet package
+1. Open VTS-Sharp.sln in an IDE of your choice
+2. Build the project
+3. A NuGet package (VTS-Sharp.*.nupkg) will be generated inside [bin/Debug](bin/Debug).
+4. Upload it on https://www.nuget.org/

--- a/NuGet~/README.md
+++ b/NuGet~/README.md
@@ -9,6 +9,7 @@ See: https://docs.unity3d.com/Manual/SpecialFolders.html
 
 ### How to publish a NuGet package
 1. Open VTS-Sharp.sln in an IDE of your choice
-2. Build the project
-3. A NuGet package (VTS-Sharp.*.nupkg) will be generated inside [bin/Debug](bin/Debug).
-4. Upload it on https://www.nuget.org/packages/manage/upload
+2. Set the version inside VTS.csproj
+3. Build the project
+4. A NuGet package (VTS-Sharp.*.nupkg) will be generated inside [bin/Debug](bin/Debug).
+5. Upload it on https://www.nuget.org/packages/manage/upload

--- a/NuGet~/VTS-Sharp.sln
+++ b/NuGet~/VTS-Sharp.sln
@@ -1,0 +1,18 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VTS", "VTS.csproj", "{E085B96C-2F16-4E6D-A991-EF29C2E1FF6C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E085B96C-2F16-4E6D-A991-EF29C2E1FF6C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E085B96C-2F16-4E6D-A991-EF29C2E1FF6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E085B96C-2F16-4E6D-A991-EF29C2E1FF6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E085B96C-2F16-4E6D-A991-EF29C2E1FF6C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+	EndGlobalSection
+EndGlobal

--- a/NuGet~/VTS.csproj
+++ b/NuGet~/VTS.csproj
@@ -11,7 +11,7 @@
         <Description>C# Library for interacting with the VTube Studio API</Description>
         <PackageProjectUrl>https://github.com/FomTarro/VTS-Sharp</PackageProjectUrl>
         <RepositoryUrl>https://github.com/FomTarro/VTS-Sharp</RepositoryUrl>
-        <RepositoryType>Public</RepositoryType>
+        <RepositoryType>git</RepositoryType>
         <Company>VTS-Sharp</Company>
         <Product>VTS-Sharp</Product>
         <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/NuGet~/VTS.csproj
+++ b/NuGet~/VTS.csproj
@@ -1,0 +1,41 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <ImplicitUsings>disable</ImplicitUsings>
+        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <PackageId>VTS-Sharp</PackageId>
+        <Version>2.0.1</Version>
+        <Title>VTS-Sharp</Title>
+        <Authors>FomTarro</Authors>
+        <Description>C# Library for interacting with the VTube Studio API</Description>
+        <PackageProjectUrl>https://github.com/FomTarro/VTS-Sharp</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/FomTarro/VTS-Sharp</RepositoryUrl>
+        <RepositoryType>Public</RepositoryType>
+        <Company>VTS-Sharp</Company>
+        <Product>VTS-Sharp</Product>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <PackageReference Include="WebSocket4Net" Version="0.15.2" />
+        <PackageReference Include="WebSocketSharp" Version="1.0.3-rc11" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Compile Include="..\**\*.cs" Exclude="**\Unity\**;Examples\**;NuGet~\**">
+            <Visible>true</Visible>
+        </Compile>
+    </ItemGroup>
+
+    <ItemGroup>
+      <None Include="..\README.md" Pack="true" PackagePath="\"/>
+    </ItemGroup>
+
+    <PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <NoWarn>$(NoWarn);1591</NoWarn>
+    </PropertyGroup>
+</Project>

--- a/NuGet~/VTS.csproj
+++ b/NuGet~/VTS.csproj
@@ -16,6 +16,7 @@
         <Product>VTS-Sharp</Product>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <Copyright>FomTarro</Copyright>
     </PropertyGroup>
 
     <ItemGroup>

--- a/NuGet~/VTS.csproj
+++ b/NuGet~/VTS.csproj
@@ -17,6 +17,7 @@
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <Copyright>FomTarro</Copyright>
+        <PackageTags>plugin csharp unity dotnet godot-engine vtuber vtube-studio</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This PR adds a simple wrapper project, that builds a NuGet package.
This feature leverages Unity's [Special Folders](https://docs.unity3d.com/Manual/SpecialFolders.html) which allows to ignore the `NuGet~` folder when imported into the Unity assets.
When not ignored, Unity will print lots of errors and refuse to build.

### How to publish a NuGet package
1. Open VTS-Sharp.sln in an IDE of your choice
2. Update the version number inside VTS.csproj
3. Build the project
4. A NuGet package (VTS-Sharp.*.nupkg) will be generated inside `bin/Debug`.
5. Upload it on https://www.nuget.org/packages/manage/upload

Handles #31
Also handles the request for project files in https://github.com/FomTarro/VTS-Sharp/pull/32#issuecomment-1687962683