### PR TITLE
FEATURE: The Item API

### DIFF
--- a/VTS/Core/CoreVTSPlugin.cs
+++ b/VTS/Core/CoreVTSPlugin.cs
@@ -935,6 +935,43 @@ namespace VTS.Core {
 			return await VTSExtensions.Async<VTSEventSubscriptionResponseData, VTSErrorData>(UnsubscribeFromModelAnimationEvent);
 		}
 
+		// Item Event
+
+		public void SubscribeToItemEvent(VTSItemEventConfigOptions config, Action<VTSItemEventData> onEvent, Action<VTSEventSubscriptionResponseData> onSubscribe, Action<VTSErrorData> onError) {
+			SubscribeToEvent<VTSItemEventSubscriptionRequestData, VTSItemEventData, VTSItemEventConfigOptions>(true, config, onEvent, onSubscribe, onError);
+		}
+		public async Task<VTSEventSubscriptionResponseData> SubscribeToItemEvent(VTSItemEventConfigOptions config, Action<VTSItemEventData> onEvent) {
+			return await VTSExtensions.Async<VTSItemEventConfigOptions, Action<VTSItemEventData>, VTSEventSubscriptionResponseData, VTSErrorData>(
+				SubscribeToItemEvent, config, onEvent);
+		}
+
+		public void UnsubscribeFromItemEvent(Action<VTSEventSubscriptionResponseData> onUnsubscribe, Action<VTSErrorData> onError) {
+			SubscribeToEvent<VTSItemEventSubscriptionRequestData, VTSItemEventData, VTSItemEventConfigOptions>(false, null, DoNothingCallback, onUnsubscribe, onError);
+		}
+		public async Task<VTSEventSubscriptionResponseData> UnsubscribeFromItemEvent() {
+			return await VTSExtensions.Async<VTSEventSubscriptionResponseData, VTSErrorData>(UnsubscribeFromItemEvent);
+		}
+
+		// Model Clicked Event
+
+		public void SubscribeToModelClickedEvent(VTSModelClickedEventConfigOptions config, Action<VTSModelClickedEventData> onEvent, Action<VTSEventSubscriptionResponseData> onSubscribe, Action<VTSErrorData> onError) {
+			SubscribeToEvent<VTSModelClickedEventSubscriptionRequestData, VTSModelClickedEventData, VTSModelClickedEventConfigOptions>(true, config, onEvent, onSubscribe, onError);
+		}
+
+		public async Task<VTSEventSubscriptionResponseData> SubscribeToModelClickedEvent(VTSModelClickedEventConfigOptions config, Action<VTSModelClickedEventData> onEvent) {
+			return await VTSExtensions.Async<VTSModelClickedEventConfigOptions, Action<VTSModelClickedEventData>, VTSEventSubscriptionResponseData, VTSErrorData>(
+				SubscribeToModelClickedEvent, config, onEvent);
+		}
+
+		public void UnsubscribeFromModelClickedEvent(Action<VTSEventSubscriptionResponseData> onUnsubscribe, Action<VTSErrorData> onError) {
+			SubscribeToEvent<VTSModelClickedEventSubscriptionRequestData, VTSModelClickedEventData, VTSModelClickedEventConfigOptions>(false, null, DoNothingCallback, onUnsubscribe, onError);
+		}
+
+		public async Task<VTSEventSubscriptionResponseData> UnsubscribeFromModelClickedEvent() {
+			return await VTSExtensions.Async<VTSEventSubscriptionResponseData, VTSErrorData>(UnsubscribeFromModelClickedEvent);
+		}
+
+
 		#endregion
 
 		#region Helper Methods 

--- a/VTS/Core/CoreVTSPlugin.cs
+++ b/VTS/Core/CoreVTSPlugin.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -626,7 +627,58 @@ namespace VTS.Core {
 			return await VTSExtensions.Async<VTSItemMoveEntry[], VTSItemMoveResponseData, VTSErrorData>(MoveItem, items);
 		}
 
-		// Request Art mesh Selection
+		// Pin/Unpin Items
+
+		private void PinItem(string itemInstanceID, VTSItemAngleRelativityMode angleRelativeTo, VTSItemSizeRelativityMode sizeRelativeTo, VTSVertexPinMode vertexPinType, ArtMeshCoordinate pinInfo, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError) {
+			VTSItemPinRequestData request = new VTSItemPinRequestData();
+			request.data.pin = true;
+			request.data.itemInstanceID = itemInstanceID;
+			request.data.vertexPinType = vertexPinType;
+			request.data.angleRelativeTo = angleRelativeTo;
+			request.data.sizeRealtiveTo = sizeRelativeTo;
+			request.data.pinInfo = pinInfo;
+			this.Socket.Send<VTSItemPinRequestData, VTSItemPinResponseData>(request, onSuccess, onError);
+		}
+
+		public void PinItemToCenter(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError) {
+			ArtMeshCoordinate coordinate = new ArtMeshCoordinate {
+				modelID = modelID,
+				artMeshID = artMeshID,
+				angle = angle,
+				size = size
+			};
+			PinItem(itemInstanceID, angleRelativeTo, sizeRelativeTo, VTSVertexPinMode.Center, coordinate, onSuccess, onError);
+		}
+
+		public void PinItemToRandom(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError) {
+			ArtMeshCoordinate coordinate = new ArtMeshCoordinate {
+				modelID = modelID,
+				artMeshID = artMeshID,
+				angle = angle,
+				size = size
+			};
+			PinItem(itemInstanceID, angleRelativeTo, sizeRelativeTo, VTSVertexPinMode.Random, coordinate, onSuccess, onError);
+		}
+
+		public void PinItemToPoint(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo, BarycentricCoordinate point, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError) {
+			ArtMeshCoordinate coordinate = new ArtMeshCoordinate {
+				modelID = modelID,
+				artMeshID = artMeshID,
+				angle = angle,
+				size = size,
+			};
+			coordinate.SetBarycentricCoodrinate(point);
+			PinItem(itemInstanceID, angleRelativeTo, sizeRelativeTo, VTSVertexPinMode.Provided, coordinate, onSuccess, onError);
+		}
+
+		public void UnpinItem(string itemInsanceID, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError) {
+			VTSItemPinRequestData request = new VTSItemPinRequestData();
+			request.data.pin = false;
+			request.data.itemInstanceID = itemInsanceID;
+			this.Socket.Send<VTSItemPinRequestData, VTSItemPinResponseData>(request, onSuccess, onError);
+		}
+
+		// Request Art Mesh Selection
 
 		public void RequestArtMeshSelection(string textOverride, string helpOverride, int count, ICollection<string> activeArtMeshes, Action<VTSArtMeshSelectionResponseData> onSuccess, Action<VTSErrorData> onError) {
 			VTSArtMeshSelectionRequestData request = new VTSArtMeshSelectionRequestData();
@@ -641,6 +693,18 @@ namespace VTS.Core {
 		public async Task<VTSArtMeshSelectionResponseData> RequestArtMeshSelection(string textOverride, string helpOverride, int count, ICollection<string> activeArtMeshes) {
 			return await VTSExtensions.Async<string, string, int, ICollection<string>, VTSArtMeshSelectionResponseData, VTSErrorData>(
 				RequestArtMeshSelection, textOverride, helpOverride, count, activeArtMeshes);
+		}
+
+		// Request Permissions
+
+		public void RequestPermission(VTSPermission permission, Action<VTSPermissionResponseData> onSuccess, Action<VTSErrorData> onError) {
+			VTSPermissionRequestData request = new VTSPermissionRequestData();
+			request.data.requestedPermission = permission;
+			this.Socket.Send<VTSPermissionRequestData, VTSPermissionResponseData>(request, onSuccess, onError);
+		}
+
+		public async Task<VTSPermissionResponseData> RequestPermission(VTSPermission permission) {
+			return await VTSExtensions.Async<VTSPermission, VTSPermissionResponseData, VTSErrorData>(RequestPermission, permission);
 		}
 
 		#endregion

--- a/VTS/Core/CoreVTSPlugin.cs
+++ b/VTS/Core/CoreVTSPlugin.cs
@@ -566,6 +566,32 @@ namespace VTS.Core {
 			return await VTSExtensions.Async<string, VTSItemLoadOptions, VTSItemLoadResponseData, VTSErrorData>(LoadItem, fileName, options);
 		}
 
+		public void LoadCustomDataItem(string fileName, string base64, VTSCustomDataItemLoadOptions options, Action<VTSItemLoadResponseData> onSuccess, Action<VTSErrorData> onError) {
+			VTSItemLoadRequestData request = new VTSItemLoadRequestData();
+			request.data.fileName = fileName;
+			request.data.positionX = options.positionX;
+			request.data.positionY = options.positionY;
+			request.data.size = options.size;
+			request.data.rotation = options.rotation;
+			request.data.fadeTime = options.fadeTime;
+			request.data.order = options.order;
+			request.data.failIfOrderTaken = options.failIfOrderTaken;
+			request.data.smoothing = options.smoothing;
+			request.data.censored = options.censored;
+			request.data.flipped = options.flipped;
+			request.data.locked = options.locked;
+			request.data.unloadWhenPluginDisconnects = options.unloadWhenPluginDisconnects;
+			// Custom Data item settings
+			request.data.customDataBase64 = base64;
+			request.data.customDataAskUserFirst = options.askUserFirst;
+			request.data.customDataSkipAskingUserIfWhitelisted = options.skipAskingUserIfWhitelisted;
+			request.data.customDataAskTimer = options.askTimer;
+			this.Socket.Send<VTSItemLoadRequestData, VTSItemLoadResponseData>(request, onSuccess, onError);
+		}
+		public async Task<VTSItemLoadResponseData> LoadCustomDataItem(string fileName, string base64, VTSCustomDataItemLoadOptions options) {
+			return await VTSExtensions.Async<string, string, VTSCustomDataItemLoadOptions, VTSItemLoadResponseData, VTSErrorData>(LoadCustomDataItem, fileName, base64, options);
+		}
+
 		// Unload Item
 
 		public void UnloadItem(VTSItemUnloadOptions options, Action<VTSItemUnloadResponseData> onSuccess, Action<VTSErrorData> onError) {
@@ -665,6 +691,12 @@ namespace VTS.Core {
 			PinItem(itemInstanceID, angleRelativeTo, sizeRelativeTo, VTSVertexPinMode.Random, coordinate, onSuccess, onError);
 		}
 
+		public async Task<VTSItemPinResponseData> PinItemToRandom(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo) {
+			return await VTSExtensions.Async<string, string, string, float, VTSItemAngleRelativityMode, float, VTSItemSizeRelativityMode, VTSItemPinResponseData, VTSErrorData>(
+				PinItemToRandom, itemInstanceID, modelID, artMeshID, angle, angleRelativeTo, size, sizeRelativeTo);
+		}
+
+
 		public void PinItemToPoint(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo, BarycentricCoordinate point, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError) {
 			ArtMeshCoordinate coordinate = new ArtMeshCoordinate {
 				modelID = modelID,
@@ -676,12 +708,24 @@ namespace VTS.Core {
 			PinItem(itemInstanceID, angleRelativeTo, sizeRelativeTo, VTSVertexPinMode.Provided, coordinate, onSuccess, onError);
 		}
 
+		public async Task<VTSItemPinResponseData> PinItemToPoint(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo, BarycentricCoordinate point) {
+			return await VTSExtensions.Async<string, string, string, float, VTSItemAngleRelativityMode, float, VTSItemSizeRelativityMode, BarycentricCoordinate, VTSItemPinResponseData, VTSErrorData>(
+				PinItemToPoint, itemInstanceID, modelID, artMeshID, angle, angleRelativeTo, size, sizeRelativeTo, point);
+		}
+
+
 		public void UnpinItem(string itemInsanceID, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError) {
 			VTSItemPinRequestData request = new VTSItemPinRequestData();
 			request.data.pin = false;
 			request.data.itemInstanceID = itemInsanceID;
 			this.Socket.Send<VTSItemPinRequestData, VTSItemPinResponseData>(request, onSuccess, onError);
 		}
+
+		public async Task<VTSItemPinResponseData> UnpinItem(string itemInstanceID) {
+			return await VTSExtensions.Async<string, VTSItemPinResponseData, VTSErrorData>(
+				UnpinItem, itemInstanceID);
+		}
+
 
 		// Request Art Mesh Selection
 

--- a/VTS/Core/CoreVTSPlugin.cs
+++ b/VTS/Core/CoreVTSPlugin.cs
@@ -650,6 +650,11 @@ namespace VTS.Core {
 			PinItem(itemInstanceID, angleRelativeTo, sizeRelativeTo, VTSVertexPinMode.Center, coordinate, onSuccess, onError);
 		}
 
+		public async Task<VTSItemPinResponseData> PinItemToCenter(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo) {
+			return await VTSExtensions.Async<string, string, string, float, VTSItemAngleRelativityMode, float, VTSItemSizeRelativityMode, VTSItemPinResponseData, VTSErrorData>(
+				PinItemToCenter, itemInstanceID, modelID, artMeshID, angle, angleRelativeTo, size, sizeRelativeTo);
+		}
+
 		public void PinItemToRandom(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError) {
 			ArtMeshCoordinate coordinate = new ArtMeshCoordinate {
 				modelID = modelID,

--- a/VTS/Core/Interfaces/IVTSPlugin.cs
+++ b/VTS/Core/Interfaces/IVTSPlugin.cs
@@ -516,6 +516,14 @@ namespace VTS.Core {
 		/// </summary>
 		/// <param name="position">The desired position information. Fields will be null-valued by default.</param>
 		Task<VTSMoveModelData> MoveModel(VTSMoveModelData.Data position);
+		void PinItemToCenter(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError);
+		Task<VTSItemPinResponseData> PinItemToCenter(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo);
+		void PinItemToRandom(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError);
+		Task<VTSItemPinResponseData> PinItemToRandom(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo);
+		void PinItemToPoint(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo, BarycentricCoordinate point, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError);
+		Task<VTSItemPinResponseData> PinItemToPoint(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo, BarycentricCoordinate point);
+		void UnpinItem(string itemInsanceID, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError);
+		Task<VTSItemPinResponseData> UnpinItem(string itemInstanceID);
 		/// <summary>
 		/// Removes a custom parameter from the currently loaded VTS model.
 		/// 
@@ -558,6 +566,22 @@ namespace VTS.Core {
 		/// <param name="count">The number of art meshes to select. Values of 0 or lower will allow the user to choose any arbitrary number of art meshes (but at least one).</param>
 		/// <param name="activeArtMeshes">A list of already-selected art meshes.</param>
 		Task<VTSArtMeshSelectionResponseData> RequestArtMeshSelection(string textOverride, string helpOverride, int count, ICollection<string> activeArtMeshes);
+		/// <summary>
+		/// Initiates a prompt in VTube Studio to request advanced permissions from the user.
+		/// 
+		/// For more info, see
+		/// <a href="https://github.com/DenchiSoft/VTubeStudio/blob/master/Permissions/README.md#requesting-permissions">https://github.com/DenchiSoft/VTubeStudio/blob/master/Permissions/README.md#requesting-permissions</a>
+		/// </summary>
+		/// <param name="permission">The permission being requested.</param>
+		void RequestPermission(VTSPermission permission, Action<VTSPermissionResponseData> onSuccess, Action<VTSErrorData> onError);
+		/// <summary>
+		/// Initiates a prompt in VTube Studio to request advanced permissions from the user.
+		/// 
+		/// For more info, see
+		/// <a href="https://github.com/DenchiSoft/VTubeStudio/blob/master/Permissions/README.md#requesting-permissions">https://github.com/DenchiSoft/VTubeStudio/blob/master/Permissions/README.md#requesting-permissions</a>
+		/// </summary>
+		/// <param name="permission">The permission being requested.</param>
+		Task<VTSPermissionResponseData> RequestPermission(VTSPermission permission);
 		/// <summary>
 		/// Overrides the physics properties of the current model. Once a plugin has overridden a model's physics, no other plugins may do so.
 		/// 
@@ -982,9 +1006,5 @@ namespace VTS.Core {
 		/// Unsubscribes from the Model Animation Event.
 		/// </summary>
 		Task<VTSEventSubscriptionResponseData> UnsubscribeFromModelAnimationEvent();
-
-
-		void RequestPermission(VTSPermission permission, Action<VTSPermissionData> onSuccess, Action<VTSErrorData> onError);
-		Task<VTSPermissionData> RequestPermission(VTSPermission permission);
 	}
 }

--- a/VTS/Core/Interfaces/IVTSPlugin.cs
+++ b/VTS/Core/Interfaces/IVTSPlugin.cs
@@ -463,6 +463,28 @@ namespace VTS.Core {
 		/// <param name="options">Configuration options about the request.</param>
 		Task<VTSItemLoadResponseData> LoadItem(string fileName, VTSItemLoadOptions options);
 		/// <summary>
+		/// Loads an item into the scene from a base64 string, with properties based on the provided options.
+		/// 
+		/// For more, see 
+		/// <a href="https://github.com/DenchiSoft/VTubeStudio#custom-data-items">https://github.com/DenchiSoft/VTubeStudio#custom-data-items</a>
+		/// </summary>
+		/// <param name="fileName">The file name of the item to load, must be a .jpg, .png or .gif.</param>
+		/// <param name="base64">The base64 string form of the image to load as an item.</param>
+		/// <param name="options">Configuration options about the request.</param>
+		/// <param name="onSuccess">Callback executed upon receiving a response.</param>
+		/// <param name="onError">Callback executed upon receiving an error.</param>
+		void LoadCustomDataItem(string fileName, string base64, VTSCustomDataItemLoadOptions options, Action<VTSItemLoadResponseData> onSuccess, Action<VTSErrorData> onError);
+		/// <summary>
+		/// Loads an item into the scene from a base64 string, with properties based on the provided options.
+		/// 
+		/// For more, see 
+		/// <a href="https://github.com/DenchiSoft/VTubeStudio#custom-data-items">https://github.com/DenchiSoft/VTubeStudio#custom-data-items</a>
+		/// </summary>
+		/// <param name="fileName">The file name of the item to load, must be a .jpg, .png or .gif.</param>
+		/// <param name="base64">The base64 string form of the image to load as an item.</param>
+		/// <param name="options">Configuration options about the request.</param>
+		Task<VTSItemLoadResponseData> LoadCustomDataItem(string fileName, string base64, VTSCustomDataItemLoadOptions options);
+		/// <summary>
 		/// Loads a VTS model by its Model ID. Will return an error if the model cannot be loaded.
 		/// 
 		/// For more info, see 
@@ -516,13 +538,117 @@ namespace VTS.Core {
 		/// </summary>
 		/// <param name="position">The desired position information. Fields will be null-valued by default.</param>
 		Task<VTSMoveModelData> MoveModel(VTSMoveModelData.Data position);
+		/// <summary>
+		/// Pins the specified item to the center of the specified ArtMesh of the specified model.
+		/// 
+		/// For more info, particularly about what each field does, see 
+		/// <a href="https://github.com/DenchiSoft/VTubeStudio#pin-items-to-the-model">https://github.com/DenchiSoft/VTubeStudio#pin-items-to-the-model</a>
+		/// </summary>
+		/// <param name="itemInstanceID">The item to pin.</param>
+		/// <param name="modelID">The model to pin it to.</param>
+		/// <param name="artMeshID">The artmesh to pin it to on that model.</param>
+		/// <param name="angle">The angle of the item.</param>
+		/// <param name="angleRelativeTo">The mode to interpert the angle value by.</param>
+		/// <param name="size">The size of the item.</param>
+		/// <param name="sizeRelativeTo">The mode to interpert the size value by.</param>
+		/// <param name="onSuccess">Callback executed upon receiving a response.</param>
+		/// <param name="onError">Callback executed upon receiving an error.</param>
 		void PinItemToCenter(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError);
+		/// <summary>
+		/// Pins the specified item to the center of the specified ArtMesh of the specified model.
+		/// 
+		/// For more info, particularly about what each field does, see 
+		/// <a href="https://github.com/DenchiSoft/VTubeStudio#pin-items-to-the-model">https://github.com/DenchiSoft/VTubeStudio#pin-items-to-the-model</a>
+		/// </summary>
+		/// <param name="itemInstanceID">The item to pin.</param>
+		/// <param name="modelID">The model to pin it to.</param>
+		/// <param name="artMeshID">The artmesh to pin it to on that model.</param>
+		/// <param name="angle">The angle of the item.</param>
+		/// <param name="angleRelativeTo">The mode to interpert the angle value by.</param>
+		/// <param name="size">The size of the item.</param>
+		/// <param name="sizeRelativeTo">The mode to interpert the size value by.</param>
+		/// <param name="onSuccess">Callback executed upon receiving a response.</param>
+		/// <param name="onError">Callback executed upon receiving an error.</param>
 		Task<VTSItemPinResponseData> PinItemToCenter(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo);
+		/// <summary>
+		/// Pins the specified item to a random point in the specified ArtMesh of the specified model.
+		/// 
+		/// For more info, particularly about what each field does, see 
+		/// <a href="https://github.com/DenchiSoft/VTubeStudio#pin-items-to-the-model">https://github.com/DenchiSoft/VTubeStudio#pin-items-to-the-model</a>
+		/// </summary>
+		/// <param name="itemInstanceID">The item to pin.</param>
+		/// <param name="modelID">The model to pin it to.</param>
+		/// <param name="artMeshID">The artmesh to pin it to on that model.</param>
+		/// <param name="angle">The angle of the item.</param>
+		/// <param name="angleRelativeTo">The mode to interpert the angle value by.</param>
+		/// <param name="size">The size of the item.</param>
+		/// <param name="sizeRelativeTo">The mode to interpert the size value by.</param>
+		/// <param name="onSuccess">Callback executed upon receiving a response.</param>
+		/// <param name="onError">Callback executed upon receiving an error.</param>
 		void PinItemToRandom(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError);
+		/// <summary>
+		/// Pins the specified item to a random point in the specified ArtMesh of the specified model.
+		/// 
+		/// For more info, particularly about what each field does, see 
+		/// <a href="https://github.com/DenchiSoft/VTubeStudio#pin-items-to-the-model">https://github.com/DenchiSoft/VTubeStudio#pin-items-to-the-model</a>
+		/// </summary>
+		/// <param name="itemInstanceID">The item to pin.</param>
+		/// <param name="modelID">The model to pin it to.</param>
+		/// <param name="artMeshID">The artmesh to pin it to on that model.</param>
+		/// <param name="angle">The angle of the item.</param>
+		/// <param name="angleRelativeTo">The mode to interpert the angle value by.</param>
+		/// <param name="size">The size of the item.</param>
+		/// <param name="sizeRelativeTo">The mode to interpert the size value by.</param>
+		/// <param name="onSuccess">Callback executed upon receiving a response.</param>
+		/// <param name="onError">Callback executed upon receiving an error.</param>
 		Task<VTSItemPinResponseData> PinItemToRandom(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo);
+		/// <summary>
+		/// Pins the specified item to a random point in the specified ArtMesh of the specified model.
+		/// 
+		/// For more info, particularly about what each field does, see 
+		/// <a href="https://github.com/DenchiSoft/VTubeStudio#pin-items-to-the-model">https://github.com/DenchiSoft/VTubeStudio#pin-items-to-the-model</a>
+		/// </summary>
+		/// <param name="itemInstanceID">The item to pin.</param>
+		/// <param name="modelID">The model to pin it to.</param>
+		/// <param name="artMeshID">The artmesh to pin it to on that model.</param>
+		/// <param name="angle">The angle of the item.</param>
+		/// <param name="angleRelativeTo">The mode to interpert the angle value by.</param>
+		/// <param name="size">The size of the item.</param>
+		/// <param name="sizeRelativeTo">The mode to interpert the size value by.</param>
+		/// <param name="point">The barycentric coordinate defining where inside the ArtMesh the item should be pinned.</point>
+		/// <param name="onSuccess">Callback executed upon receiving a response.</param>
+		/// <param name="onError">Callback executed upon receiving an error.</param>
 		void PinItemToPoint(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo, BarycentricCoordinate point, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError);
+		/// <summary>
+		/// Pins the specified item to a random point in the specified ArtMesh of the specified model.
+		/// 
+		/// For more info, particularly about what each field does, see 
+		/// <a href="https://github.com/DenchiSoft/VTubeStudio#pin-items-to-the-model">https://github.com/DenchiSoft/VTubeStudio#pin-items-to-the-model</a>
+		/// </summary>
+		/// <param name="itemInstanceID">The item to pin.</param>
+		/// <param name="modelID">The model to pin it to.</param>
+		/// <param name="artMeshID">The artmesh to pin it to on that model.</param>
+		/// <param name="angle">The angle of the item.</param>
+		/// <param name="angleRelativeTo">The mode to interpert the angle value by.</param>
+		/// <param name="size">The size of the item.</param>
+		/// <param name="sizeRelativeTo">The mode to interpert the size value by.</param>
+		/// <param name="point">The barycentric coordinate defining where inside the ArtMesh the item should be pinned.</point>
+		/// <param name="onSuccess">Callback executed upon receiving a response.</param>
+		/// <param name="onError">Callback executed upon receiving an error.</param>
 		Task<VTSItemPinResponseData> PinItemToPoint(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo, BarycentricCoordinate point);
-		void UnpinItem(string itemInsanceID, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError);
+		/// <summary>
+		/// Unpins the specified item from wherever it is pinned to.
+		/// </summary>
+		/// <param name="itemInstanceID">The item to unpin.</param>
+		/// <param name="onSuccess">Callback executed upon receiving a response.</param>
+		/// <param name="onError">Callback executed upon receiving an error.</param>
+		void UnpinItem(string itemInstanceID, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError);
+		/// <summary>
+		/// Unpins the specified item from wherever it is pinned to.
+		/// </summary>
+		/// <param name="itemInstanceID">The item to unpin.</param>
+		/// <param name="onSuccess">Callback executed upon receiving a response.</param>
+		/// <param name="onError">Callback executed upon receiving an error.</param>
 		Task<VTSItemPinResponseData> UnpinItem(string itemInstanceID);
 		/// <summary>
 		/// Removes a custom parameter from the currently loaded VTS model.
@@ -573,6 +699,8 @@ namespace VTS.Core {
 		/// <a href="https://github.com/DenchiSoft/VTubeStudio/blob/master/Permissions/README.md#requesting-permissions">https://github.com/DenchiSoft/VTubeStudio/blob/master/Permissions/README.md#requesting-permissions</a>
 		/// </summary>
 		/// <param name="permission">The permission being requested.</param>
+		/// <param name="onSuccess">Callback executed upon receiving a response.</param>
+		/// <param name="onError">Callback executed upon receiving an error.</param>
 		void RequestPermission(VTSPermission permission, Action<VTSPermissionResponseData> onSuccess, Action<VTSErrorData> onError);
 		/// <summary>
 		/// Initiates a prompt in VTube Studio to request advanced permissions from the user.

--- a/VTS/Core/Interfaces/IVTSPlugin.cs
+++ b/VTS/Core/Interfaces/IVTSPlugin.cs
@@ -982,5 +982,9 @@ namespace VTS.Core {
 		/// Unsubscribes from the Model Animation Event.
 		/// </summary>
 		Task<VTSEventSubscriptionResponseData> UnsubscribeFromModelAnimationEvent();
+
+
+		void RequestPermission(VTSPermission permission, Action<VTSPermissionData> onSuccess, Action<VTSErrorData> onError);
+		Task<VTSPermissionData> RequestPermission(VTSPermission permission);
 	}
 }

--- a/VTS/Core/Interfaces/IVTSPlugin.cs
+++ b/VTS/Core/Interfaces/IVTSPlugin.cs
@@ -955,6 +955,48 @@ namespace VTS.Core {
 		/// <param name="onSubscribe">Callback executed upon successfully subscribing to the event.</param>
 		Task<VTSEventSubscriptionResponseData> SubscribeToTrackingEvent(Action<VTSTrackingEventData> onEvent);
 		/// <summary>
+		/// Subscribes to the Item Event.
+		/// 
+		/// For more info, see 
+		/// <a href="https://github.com/DenchiSoft/VTubeStudio/tree/master/Events#item-event">https://github.com/DenchiSoft/VTubeStudio/tree/master/Events#item-event</a>
+		/// </summary>
+		/// <param name="config">Configuration options about the subscription.</param>
+		/// <param name="onEvent">Callback to execute upon receiving an event.</param>
+		/// <param name="onSubscribe">Callback executed upon successfully subscribing to the event.</param>
+		/// <param name="onError">Callback executed upon receiving an error.</param>
+		void SubscribeToItemEvent(VTSItemEventConfigOptions config, Action<VTSItemEventData> onEvent, Action<VTSEventSubscriptionResponseData> onSubscribe, Action<VTSErrorData> onError);
+		/// <summary>
+		/// Subscribes to the Item Event.
+		/// 
+		/// For more info, see 
+		/// <a href="https://github.com/DenchiSoft/VTubeStudio/tree/master/Events#item-event">https://github.com/DenchiSoft/VTubeStudio/tree/master/Events#item-event</a>
+		/// </summary>
+		/// <param name="config">Configuration options about the subscription.</param>
+		/// <param name="onEvent">Callback to execute upon receiving an event.</param>
+		/// <param name="onSubscribe">Callback executed upon successfully subscribing to the event.</param>
+		Task<VTSEventSubscriptionResponseData> SubscribeToItemEvent(VTSItemEventConfigOptions config, Action<VTSItemEventData> onEvent);
+		/// <summary>
+		/// Subscribes to the Model Clicked Event.
+		/// 
+		/// For more info, see 
+		/// <a href="https://github.com/DenchiSoft/VTubeStudio/tree/master/Events#model-clicked-event">https://github.com/DenchiSoft/VTubeStudio/tree/master/Events#model-clicked-event</a>
+		/// </summary>
+		/// <param name="config">Configuration options about the subscription.</param>
+		/// <param name="onEvent">Callback to execute upon receiving an event.</param>
+		/// <param name="onSubscribe">Callback executed upon successfully subscribing to the event.</param>
+		/// <param name="onError">Callback executed upon receiving an error.</param>
+		void SubscribeToModelClickedEvent(VTSModelClickedEventConfigOptions config, Action<VTSModelClickedEventData> onEvent, Action<VTSEventSubscriptionResponseData> onSubscribe, Action<VTSErrorData> onError);
+		/// <summary>
+		/// Subscribes to the Model Clicked Event.
+		/// 
+		/// For more info, see 
+		/// <a href="https://github.com/DenchiSoft/VTubeStudio/tree/master/Events#model-clicked-event">https://github.com/DenchiSoft/VTubeStudio/tree/master/Events#model-clicked-event</a>
+		/// </summary>
+		/// <param name="config">Configuration options about the subscription.</param>
+		/// <param name="onEvent">Callback to execute upon receiving an event.</param>
+		/// <param name="onSubscribe">Callback executed upon successfully subscribing to the event.</param>
+		Task<VTSEventSubscriptionResponseData> SubscribeToModelClickedEvent(VTSModelClickedEventConfigOptions config, Action<VTSModelClickedEventData> onEvent);
+		/// <summary>
 		/// Tints matched components of the current art mesh.
 		/// 
 		/// For more info, see 
@@ -1134,5 +1176,25 @@ namespace VTS.Core {
 		/// Unsubscribes from the Model Animation Event.
 		/// </summary>
 		Task<VTSEventSubscriptionResponseData> UnsubscribeFromModelAnimationEvent();
+		/// <summary>
+		/// Unsubscribes from the Item Event.
+		/// </summary>
+		/// <param name="onUnsubscribe">Callback executed upon successfully unsubscribing from the event.</param>
+		/// <param name="onError">Callback executed upon receiving an error.</param>
+		void UnsubscribeFromItemEvent(Action<VTSEventSubscriptionResponseData> onUnsubscribe, Action<VTSErrorData> onError);
+		/// <summary>
+		/// Unsubscribes from the Item Event.
+		/// </summary>
+		Task<VTSEventSubscriptionResponseData> UnsubscribeFromItemEvent();
+		/// <summary>
+		/// Unsubscribes from the Model Clicked Event.
+		/// </summary>
+		/// <param name="onUnsubscribe">Callback executed upon successfully unsubscribing from the event.</param>
+		/// <param name="onError">Callback executed upon receiving an error.</param>
+		void UnsubscribeFromModelClickedEvent(Action<VTSEventSubscriptionResponseData> onUnsubscribe, Action<VTSErrorData> onError);
+		/// <summary>
+		/// Unsubscribes from the Model Clicked Event.
+		/// </summary>
+		Task<VTSEventSubscriptionResponseData> UnsubscribeFromModelClickedEvent();
 	}
 }

--- a/VTS/Core/Models/Enums/ErrorID.cs
+++ b/VTS/Core/Models/Enums/ErrorID.cs
@@ -1,169 +1,168 @@
 ﻿using System;
 
 namespace VTS.Core {
-	/// <summary>
-/// Enum for API-related errors.
-/// </summary>
-public enum ErrorID
-{
-    // General errors
-    InternalServerError = 0,
-    APIAccessDeactivated = 1,
-    JSONInvalid = 2,
-    APINameInvalid = 3,
-    APIVersionInvalid = 4,
-    RequestIDInvalid = 5,
-    RequestTypeMissingOrEmpty = 6,
-    RequestTypeUnknown = 7,
-    RequestRequiresAuthetication = 8,
-    RequestRequiresPermission = 9, // Returned when a request requires a certain permission that has not been granted for this plugin.
+    /// <summary>
+    /// Enum for API-related errors.
+    /// </summary>
+    public enum ErrorID {
+        // General errors
+        InternalServerError = 0,
+        APIAccessDeactivated = 1,
+        JSONInvalid = 2,
+        APINameInvalid = 3,
+        APIVersionInvalid = 4,
+        RequestIDInvalid = 5,
+        RequestTypeMissingOrEmpty = 6,
+        RequestTypeUnknown = 7,
+        RequestRequiresAuthetication = 8,
+        RequestRequiresPermission = 9, // Returned when a request requires a certain permission that has not been granted for this plugin.
 
-    // Errors related to AuthenticationTokenRequest
-    TokenRequestDenied = 50,
-    TokenRequestCurrentlyOngoing = 51,
-    TokenRequestPluginNameInvalid = 52,
-    TokenRequestDeveloperNameInvalid = 53,
-    TokenRequestPluginIconInvalid = 54,
+        // Errors related to AuthenticationTokenRequest
+        TokenRequestDenied = 50,
+        TokenRequestCurrentlyOngoing = 51,
+        TokenRequestPluginNameInvalid = 52,
+        TokenRequestDeveloperNameInvalid = 53,
+        TokenRequestPluginIconInvalid = 54,
 
-    // Errors related to AuthenticationRequest
-    AuthenticationTokenMissing = 100,
-    AuthenticationPluginNameMissing = 101,
-    AuthenticationPluginDeveloperMissing = 102,
+        // Errors related to AuthenticationRequest
+        AuthenticationTokenMissing = 100,
+        AuthenticationPluginNameMissing = 101,
+        AuthenticationPluginDeveloperMissing = 102,
 
-    // Errors related to ModelLoadRequest
-    ModelIDMissing = 150,
-    ModelIDInvalid = 151,
-    ModelIDNotFound = 152,
-    ModelLoadCooldownNotOver = 153,
-    CannotCurrentlyChangeModel = 154,
+        // Errors related to ModelLoadRequest
+        ModelIDMissing = 150,
+        ModelIDInvalid = 151,
+        ModelIDNotFound = 152,
+        ModelLoadCooldownNotOver = 153,
+        CannotCurrentlyChangeModel = 154,
 
-    // Errors related to HotkeyTriggerRequest
-    HotkeyQueueFull = 200, // Only a certain amount of hotkey activations can be queued until you have to wait for execution completion.
-    HotkeyExecutionFailedBecauseNoModelLoaded = 201,
-    HotkeyIDNotFoundInModel = 202,
-    HotkeyCooldownNotOver = 203, // Individual hotkeys have a global 5 second cooldown
-    HotkeyIDFoundButHotkeyDataInvalid = 204, // For example missing files for expression/animation hotkey
-    HotkeyExecutionFailedBecauseBadState = 205, // For example when trying to load a model and the user has certain config windows open that temporarily prevent that
-    HotkeyUnknownExecutionFailure = 206,
-    HotkeyExecutionFailedBecauseLive2DItemNotFound = 207, // When triggering hotkeys in Live2D items, this will be returned if the requested Live2D item has not been found.
-    HotkeyExecutionFailedBecauseLive2DItemsDoNotSupportThisHotkeyType = 208, // Only a subset of hotkey actions are supported in Live2D items, for example Expression hotkeys.
-    
-    // Errors related to ColorTintRequest
-    ColorTintRequestNoModelLoaded = 250,
-    ColorTintRequestMatchOrColorMissing = 251,
-    ColorTintRequestInvalidColorValue = 252,
+        // Errors related to HotkeyTriggerRequest
+        HotkeyQueueFull = 200, // Only a certain amount of hotkey activations can be queued until you have to wait for execution completion.
+        HotkeyExecutionFailedBecauseNoModelLoaded = 201,
+        HotkeyIDNotFoundInModel = 202,
+        HotkeyCooldownNotOver = 203, // Individual hotkeys have a global 5 second cooldown
+        HotkeyIDFoundButHotkeyDataInvalid = 204, // For example missing files for expression/animation hotkey
+        HotkeyExecutionFailedBecauseBadState = 205, // For example when trying to load a model and the user has certain config windows open that temporarily prevent that
+        HotkeyUnknownExecutionFailure = 206,
+        HotkeyExecutionFailedBecauseLive2DItemNotFound = 207, // When triggering hotkeys in Live2D items, this will be returned if the requested Live2D item has not been found.
+        HotkeyExecutionFailedBecauseLive2DItemsDoNotSupportThisHotkeyType = 208, // Only a subset of hotkey actions are supported in Live2D items, for example Expression hotkeys.
 
-    // Errors related to MoveModelRequest
-    MoveModelRequestNoModelLoaded = 300,
-    MoveModelRequestMissingFields = 301,
-    MoveModelRequestValuesOutOfRange = 302,
-    
-    // Errors related to ParameterCreationRequest
-    CustomParamNameInvalid = 350,
-    CustomParamValuesInvalid = 351,
-    CustomParamAlreadyCreatedByOtherPlugin = 352,
-    CustomParamExplanationTooLong = 353,
-    CustomParamDefaultParamNameNotAllowed = 354, // When you use names of default param names, like MouthX, FaceAngleZ, MouthSmile, ...
-    CustomParamLimitPerPluginExceeded = 355,
-    CustomParamLimitTotalExceeded = 356,
+        // Errors related to ColorTintRequest
+        ColorTintRequestNoModelLoaded = 250,
+        ColorTintRequestMatchOrColorMissing = 251,
+        ColorTintRequestInvalidColorValue = 252,
 
-    // Errors related to ParameterDeletionRequest
-    CustomParamDeletionNameInvalid = 400,
-    CustomParamDeletionNotFound = 401, // Trying to delete a parameter that doesn't exist
-    CustomParamDeletionCreatedByOtherPlugin = 402, // Trying to delete a parameter created by another plugin
-    CustomParamDeletionCannotDeleteDefaultParam = 403,
-    
-    // Errors related to InjectParameterDataRequest
-    InjectDataNoDataProvided = 450,
-    InjectDataValueInvalid = 451,
-    InjectDataWeightInvalid = 452,
-    InjectDataParamNameNotFound = 453, // Trying to send data for parameter that doesn't exist
-    InjectDataParamControlledByOtherPlugin = 454, // Only one plugin can send data for a parameter at a time
-    InjectDataModeUnknown = 455, // Only "add" and "set" can be used. If no mode is provided, "set" will be used.
-    
-    // Errors related to ParameterValueRequest
-    ParameterValueRequestParameterNotFound = 500,
+        // Errors related to MoveModelRequest
+        MoveModelRequestNoModelLoaded = 300,
+        MoveModelRequestMissingFields = 301,
+        MoveModelRequestValuesOutOfRange = 302,
 
-    // Errors related to NDIConfigRequest
-    NDIConfigCooldownNotOver = 550,
-    NDIConfigResolutionInvalid = 551,
+        // Errors related to ParameterCreationRequest
+        CustomParamNameInvalid = 350,
+        CustomParamValuesInvalid = 351,
+        CustomParamAlreadyCreatedByOtherPlugin = 352,
+        CustomParamExplanationTooLong = 353,
+        CustomParamDefaultParamNameNotAllowed = 354, // When you use names of default param names, like MouthX, FaceAngleZ, MouthSmile, ...
+        CustomParamLimitPerPluginExceeded = 355,
+        CustomParamLimitTotalExceeded = 356,
 
-    // Errors related to ExpressionStateRequest
-    ExpressionStateRequestInvalidFilename = 600,
-    ExpressionStateRequestFileNotFound = 601,
+        // Errors related to ParameterDeletionRequest
+        CustomParamDeletionNameInvalid = 400,
+        CustomParamDeletionNotFound = 401, // Trying to delete a parameter that doesn't exist
+        CustomParamDeletionCreatedByOtherPlugin = 402, // Trying to delete a parameter created by another plugin
+        CustomParamDeletionCannotDeleteDefaultParam = 403,
 
-    // Errors related to ExpressionStateRequest
-    ExpressionActivationRequestInvalidFilename = 650,
-    ExpressionActivationRequestFileNotFound = 651,
-    ExpressionActivationRequestNoModelLoaded = 652,
-    
-    // Errors related to SetCurrentModelPhysicsRequest
-    SetCurrentModelPhysicsRequestNoModelLoaded = 700,
-    SetCurrentModelPhysicsRequestModelHasNoPhysics = 701,
-    SetCurrentModelPhysicsRequestPhysicsControlledByOtherPlugin = 702, 
-    SetCurrentModelPhysicsRequestNoOverridesProvided = 703,
-    SetCurrentModelPhysicsRequestPhysicsGroupIDNotFound = 704,
-    SetCurrentModelPhysicsRequestNoOverrideValueProvided = 705,
-    SetCurrentModelPhysicsRequestDuplicatePhysicsGroupID = 706,
-    
-    // Errors related to ItemLoadRequest
-    ItemFileNameMissing = 750,
-    ItemFileNameNotFound = 751,
-    ItemLoadLoadCooldownNotOver = 752, // Not used anymore. The cooldown for loading items has been removed.
-    CannotCurrentlyLoadItem = 753, // This is usually because the user has menus open that prevent items from being loaded.
-    CannotLoadItemSceneFull = 754,
-    ItemOrderInvalid = 755,
-    ItemOrderAlreadyTaken = 756,
-    ItemLoadValuesInvalid = 757, // Invalid values for fields like size, position, ...
-    ItemCustomDataInvalid = 758, // Invalid values for custom data field (customDataBase64). Happens when data is provided here but it's no valid JPG/PNG data or image dimensions are invalid.
-    ItemCustomDataLoadRequestRejectedByUser = 759, // User rejected to load the custom data item the plugin requested.
-    ItemCustomDataLoadRequestRejectedByUser = 760, // You requested a custom data image item to be loaded but the user rejected it.
-    
-    // Errors related to ItemUnloadRequest
-    CannotCurrentlyUnloadItem = 800,  // This is usually because the user has menus open that prevent items from being unloaded.
+        // Errors related to InjectParameterDataRequest
+        InjectDataNoDataProvided = 450,
+        InjectDataValueInvalid = 451,
+        InjectDataWeightInvalid = 452,
+        InjectDataParamNameNotFound = 453, // Trying to send data for parameter that doesn't exist
+        InjectDataParamControlledByOtherPlugin = 454, // Only one plugin can send data for a parameter at a time
+        InjectDataModeUnknown = 455, // Only "add" and "set" can be used. If no mode is provided, "set" will be used.
 
-    // Errors related to ItemAnimationControlRequest
-    ItemAnimationControlInstanceIDNotFound = 850,
-    ItemAnimationControlUnsupportedItemType = 851, // Returned when trying to use this request for Live2D items.
-    ItemAnimationControlAutoStopFramesInvalid = 852, // Auto-stop frames indices have to be between 0 and the last frame index of the animated item.
-    ItemAnimationControlTooManyAutoStopFrames = 853, // Maximum allowed number per item is 1024.
-    ItemAnimationControlSimpleImageDoesNotSupportAnim = 854, // You can set stuff like transparency and brightness for normal PNG/JPG items, but nothing animation-related.
+        // Errors related to ParameterValueRequest
+        ParameterValueRequestParameterNotFound = 500,
 
-    // Errors related to ItemMoveRequest
-    ItemMoveRequestInstanceIDNotFound = 900,
-    ItemMoveRequestInvalidFadeMode = 901,
-    ItemMoveRequestItemOrderTakenOrInvalid = 902,
-    ItemMoveRequestCannotCurrentlyChangeOrder = 903, // Cannot change order when any windows are open.
-    
-    // Errors related to EventSubscriptionRequest
-    EventSubscriptionRequestEventTypeUnknown = 950,
+        // Errors related to NDIConfigRequest
+        NDIConfigCooldownNotOver = 550,
+        NDIConfigResolutionInvalid = 551,
 
-    // Errors related to ArtMeshSelectionRequest
-    ArtMeshSelectionRequestNoModelLoaded = 1000, // Cannot start request because no model is loaded.
-    ArtMeshSelectionRequestOtherWindowsOpen = 1001, // Other windows are currently open, can't start request.
-    ArtMeshSelectionRequestModelDoesNotHaveArtMesh = 1002, // At least one of the "active" ArtMeshes you provided does not exist in the model.
-    ArtMeshSelectionRequestArtMeshIDListError = 1003, // Your "active" ArtMesh ID list is too long.
+        // Errors related to ExpressionStateRequest
+        ExpressionStateRequestInvalidFilename = 600,
+        ExpressionStateRequestFileNotFound = 601,
 
-    // Errors related to ItemPinRequest
-    ItemPinRequestGivenItemNotLoaded = 1050,
-    ItemPinRequestInvalidAngleOrSizeType = 1051,
-    ItemPinRequestModelNotFound = 1052,
-    ItemPinRequestArtMeshNotFound = 1053,
-    ItemPinRequestPinPositionInvalid = 1054,
+        // Errors related to ExpressionStateRequest
+        ExpressionActivationRequestInvalidFilename = 650,
+        ExpressionActivationRequestFileNotFound = 651,
+        ExpressionActivationRequestNoModelLoaded = 652,
 
-    // Errors related to PermissionRequest
-    PermissionRequestUnknownPermission = 1100,
-    PermissionRequestCannotRequestRightNow = 1101, // Permission config window is open.
-    PermissionRequestFileProblem = 1102, // Could not open or write permission file for this plugin.
-    
-    // -------------- EVENT CONFIG ERRORS --------------
-    
-    EVENT_OFFSET = 100000,
+        // Errors related to SetCurrentModelPhysicsRequest
+        SetCurrentModelPhysicsRequestNoModelLoaded = 700,
+        SetCurrentModelPhysicsRequestModelHasNoPhysics = 701,
+        SetCurrentModelPhysicsRequestPhysicsControlledByOtherPlugin = 702,
+        SetCurrentModelPhysicsRequestNoOverridesProvided = 703,
+        SetCurrentModelPhysicsRequestPhysicsGroupIDNotFound = 704,
+        SetCurrentModelPhysicsRequestNoOverrideValueProvided = 705,
+        SetCurrentModelPhysicsRequestDuplicatePhysicsGroupID = 706,
 
-    // Event subscription errors for TestEvent
-    Event_TestEvent_TestMessageTooLong = EVENT_OFFSET + 0,
+        // Errors related to ItemLoadRequest
+        ItemFileNameMissing = 750,
+        ItemFileNameNotFound = 751,
+        ItemLoadLoadCooldownNotOver = 752, // Not used anymore. The cooldown for loading items has been removed.
+        CannotCurrentlyLoadItem = 753, // This is usually because the user has menus open that prevent items from being loaded.
+        CannotLoadItemSceneFull = 754,
+        ItemOrderInvalid = 755,
+        ItemOrderAlreadyTaken = 756,
+        ItemLoadValuesInvalid = 757, // Invalid values for fields like size, position, ...
+        ItemCustomDataInvalid = 758, // Invalid values for custom data field (customDataBase64). Happens when data is provided here but it's no valid JPG/PNG data or image dimensions are invalid.
+        ItemCustomDataCannotAskRightNow = 759, // Max. number of item load prompts are already currently shown to the user.
+        ItemCustomDataLoadRequestRejectedByUser = 760, // You requested a custom data image item to be loaded but the user rejected it.
 
-    // Event subscription errors for ModelLoadedEvent
-    Event_ModelLoadedEvent_ModelIDInvalid = EVENT_OFFSET + 50
-}
+        // Errors related to ItemUnloadRequest
+        CannotCurrentlyUnloadItem = 800,  // This is usually because the user has menus open that prevent items from being unloaded.
+
+        // Errors related to ItemAnimationControlRequest
+        ItemAnimationControlInstanceIDNotFound = 850,
+        ItemAnimationControlUnsupportedItemType = 851, // Returned when trying to use this request for Live2D items.
+        ItemAnimationControlAutoStopFramesInvalid = 852, // Auto-stop frames indices have to be between 0 and the last frame index of the animated item.
+        ItemAnimationControlTooManyAutoStopFrames = 853, // Maximum allowed number per item is 1024.
+        ItemAnimationControlSimpleImageDoesNotSupportAnim = 854, // You can set stuff like transparency and brightness for normal PNG/JPG items, but nothing animation-related.
+
+        // Errors related to ItemMoveRequest
+        ItemMoveRequestInstanceIDNotFound = 900,
+        ItemMoveRequestInvalidFadeMode = 901,
+        ItemMoveRequestItemOrderTakenOrInvalid = 902,
+        ItemMoveRequestCannotCurrentlyChangeOrder = 903, // Cannot change order when any windows are open.
+
+        // Errors related to EventSubscriptionRequest
+        EventSubscriptionRequestEventTypeUnknown = 950,
+
+        // Errors related to ArtMeshSelectionRequest
+        ArtMeshSelectionRequestNoModelLoaded = 1000, // Cannot start request because no model is loaded.
+        ArtMeshSelectionRequestOtherWindowsOpen = 1001, // Other windows are currently open, can't start request.
+        ArtMeshSelectionRequestModelDoesNotHaveArtMesh = 1002, // At least one of the "active" ArtMeshes you provided does not exist in the model.
+        ArtMeshSelectionRequestArtMeshIDListError = 1003, // Your "active" ArtMesh ID list is too long.
+
+        // Errors related to ItemPinRequest
+        ItemPinRequestGivenItemNotLoaded = 1050,
+        ItemPinRequestInvalidAngleOrSizeType = 1051,
+        ItemPinRequestModelNotFound = 1052,
+        ItemPinRequestArtMeshNotFound = 1053,
+        ItemPinRequestPinPositionInvalid = 1054,
+
+        // Errors related to PermissionRequest
+        PermissionRequestUnknownPermission = 1100,
+        PermissionRequestCannotRequestRightNow = 1101, // Permission config window is open.
+        PermissionRequestFileProblem = 1102, // Could not open or write permission file for this plugin.
+
+        // -------------- EVENT CONFIG ERRORS --------------
+
+        EVENT_OFFSET = 100000,
+
+        // Event subscription errors for TestEvent
+        Event_TestEvent_TestMessageTooLong = EVENT_OFFSET + 0,
+
+        // Event subscription errors for ModelLoadedEvent
+        Event_ModelLoadedEvent_ModelIDInvalid = EVENT_OFFSET + 50
+    }
 }

--- a/VTS/Core/Models/Enums/ErrorID.cs
+++ b/VTS/Core/Models/Enums/ErrorID.cs
@@ -2,146 +2,168 @@
 
 namespace VTS.Core {
 	/// <summary>
-	/// Enum for API-related errors.
-	/// </summary>
-	[Serializable]
-	public enum ErrorID {
-		// General errors
-		InternalServerError = 0,
-		APIAccessDeactivated = 1,
-		JSONInvalid = 2,
-		APINameInvalid = 3,
-		APIVersionInvalid = 4,
-		RequestIDInvalid = 5,
-		RequestTypeMissingOrEmpty = 6,
-		RequestTypeUnknown = 7,
-		RequestRequiresAuthetication = 8,
+/// Enum for API-related errors.
+/// </summary>
+public enum ErrorID
+{
+    // General errors
+    InternalServerError = 0,
+    APIAccessDeactivated = 1,
+    JSONInvalid = 2,
+    APINameInvalid = 3,
+    APIVersionInvalid = 4,
+    RequestIDInvalid = 5,
+    RequestTypeMissingOrEmpty = 6,
+    RequestTypeUnknown = 7,
+    RequestRequiresAuthetication = 8,
+    RequestRequiresPermission = 9, // Returned when a request requires a certain permission that has not been granted for this plugin.
 
-		// Errors related to AuthenticationTokenRequest
-		TokenRequestDenied = 50,
-		TokenRequestCurrentlyOngoing = 51,
-		TokenRequestPluginNameInvalid = 52,
-		TokenRequestDeveloperNameInvalid = 53,
-		TokenRequestPluginIconInvalid = 54,
+    // Errors related to AuthenticationTokenRequest
+    TokenRequestDenied = 50,
+    TokenRequestCurrentlyOngoing = 51,
+    TokenRequestPluginNameInvalid = 52,
+    TokenRequestDeveloperNameInvalid = 53,
+    TokenRequestPluginIconInvalid = 54,
 
-		// Errors related to AuthenticationRequest
-		AuthenticationTokenMissing = 100,
-		AuthenticationPluginNameMissing = 101,
-		AuthenticationPluginDeveloperMissing = 102,
+    // Errors related to AuthenticationRequest
+    AuthenticationTokenMissing = 100,
+    AuthenticationPluginNameMissing = 101,
+    AuthenticationPluginDeveloperMissing = 102,
 
-		// Errors related to ModelLoadRequest
-		ModelIDMissing = 150,
-		ModelIDInvalid = 151,
-		ModelIDNotFound = 152,
-		ModelLoadCooldownNotOver = 153,
-		CannotCurrentlyChangeModel = 154,
+    // Errors related to ModelLoadRequest
+    ModelIDMissing = 150,
+    ModelIDInvalid = 151,
+    ModelIDNotFound = 152,
+    ModelLoadCooldownNotOver = 153,
+    CannotCurrentlyChangeModel = 154,
 
-		// Errors related to HotkeyTriggerRequest
-		HotkeyQueueFull = 200, // Only a certain amount of hotkey activations can be queued until you have to wait for execution completion.
-		HotkeyExecutionFailedBecauseNoModelLoaded = 201,
-		HotkeyIDNotFoundInModel = 202,
-		HotkeyCooldownNotOver = 203, // Individual hotkeys have a global 5 second cooldown
-		HotkeyIDFoundButHotkeyDataInvalid = 204, // For example missing files for expression/animation hotkey
-		HotkeyExecutionFailedBecauseBadState = 205, // For example when trying to load a model and the user has certain config windows open that temporarily prevent that
-		HotkeyUnknownExecutionFailure = 206,
-		HotkeyExecutionFailedBecauseLive2DItemNotFound = 207, // When triggering hotkeys in Live2D items, this will be returned if the requested Live2D item has not been found.
-		HotkeyExecutionFailedBecauseLive2DItemsDoNotSupportThisHotkeyType = 208, // Only a subset of hotkey actions are supported in Live2D items, for example Expression hotkeys.
+    // Errors related to HotkeyTriggerRequest
+    HotkeyQueueFull = 200, // Only a certain amount of hotkey activations can be queued until you have to wait for execution completion.
+    HotkeyExecutionFailedBecauseNoModelLoaded = 201,
+    HotkeyIDNotFoundInModel = 202,
+    HotkeyCooldownNotOver = 203, // Individual hotkeys have a global 5 second cooldown
+    HotkeyIDFoundButHotkeyDataInvalid = 204, // For example missing files for expression/animation hotkey
+    HotkeyExecutionFailedBecauseBadState = 205, // For example when trying to load a model and the user has certain config windows open that temporarily prevent that
+    HotkeyUnknownExecutionFailure = 206,
+    HotkeyExecutionFailedBecauseLive2DItemNotFound = 207, // When triggering hotkeys in Live2D items, this will be returned if the requested Live2D item has not been found.
+    HotkeyExecutionFailedBecauseLive2DItemsDoNotSupportThisHotkeyType = 208, // Only a subset of hotkey actions are supported in Live2D items, for example Expression hotkeys.
+    
+    // Errors related to ColorTintRequest
+    ColorTintRequestNoModelLoaded = 250,
+    ColorTintRequestMatchOrColorMissing = 251,
+    ColorTintRequestInvalidColorValue = 252,
 
-		// Errors related to ColorTintRequest
-		ColorTintRequestNoModelLoaded = 250,
-		ColorTintRequestMatchOrColorMissing = 251,
-		ColorTintRequestInvalidColorValue = 252,
+    // Errors related to MoveModelRequest
+    MoveModelRequestNoModelLoaded = 300,
+    MoveModelRequestMissingFields = 301,
+    MoveModelRequestValuesOutOfRange = 302,
+    
+    // Errors related to ParameterCreationRequest
+    CustomParamNameInvalid = 350,
+    CustomParamValuesInvalid = 351,
+    CustomParamAlreadyCreatedByOtherPlugin = 352,
+    CustomParamExplanationTooLong = 353,
+    CustomParamDefaultParamNameNotAllowed = 354, // When you use names of default param names, like MouthX, FaceAngleZ, MouthSmile, ...
+    CustomParamLimitPerPluginExceeded = 355,
+    CustomParamLimitTotalExceeded = 356,
 
-		// Errors related to MoveModelRequest
-		MoveModelRequestNoModelLoaded = 300,
-		MoveModelRequestMissingFields = 301,
-		MoveModelRequestValuesOutOfRange = 302,
+    // Errors related to ParameterDeletionRequest
+    CustomParamDeletionNameInvalid = 400,
+    CustomParamDeletionNotFound = 401, // Trying to delete a parameter that doesn't exist
+    CustomParamDeletionCreatedByOtherPlugin = 402, // Trying to delete a parameter created by another plugin
+    CustomParamDeletionCannotDeleteDefaultParam = 403,
+    
+    // Errors related to InjectParameterDataRequest
+    InjectDataNoDataProvided = 450,
+    InjectDataValueInvalid = 451,
+    InjectDataWeightInvalid = 452,
+    InjectDataParamNameNotFound = 453, // Trying to send data for parameter that doesn't exist
+    InjectDataParamControlledByOtherPlugin = 454, // Only one plugin can send data for a parameter at a time
+    InjectDataModeUnknown = 455, // Only "add" and "set" can be used. If no mode is provided, "set" will be used.
+    
+    // Errors related to ParameterValueRequest
+    ParameterValueRequestParameterNotFound = 500,
 
-		// Errors related to ParameterCreationRequest
-		CustomParamNameInvalid = 350,
-		CustomParamValuesInvalid = 351,
-		CustomParamAlreadyCreatedByOtherPlugin = 352,
-		CustomParamExplanationTooLong = 353,
-		CustomParamDefaultParamNameNotAllowed = 354, // When you use names of default param names, like MouthX, FaceAngleZ, MouthSmile, ...
-		CustomParamLimitPerPluginExceeded = 355,
-		CustomParamLimitTotalExceeded = 356,
+    // Errors related to NDIConfigRequest
+    NDIConfigCooldownNotOver = 550,
+    NDIConfigResolutionInvalid = 551,
 
-		// Errors related to ParameterDeletionRequest
-		CustomParamDeletionNameInvalid = 400,
-		CustomParamDeletionNotFound = 401, // Trying to delete a parameter that doesn't exist
-		CustomParamDeletionCreatedByOtherPlugin = 402, // Trying to delete a parameter created by another plugin
-		CustomParamDeletionCannotDeleteDefaultParam = 403,
+    // Errors related to ExpressionStateRequest
+    ExpressionStateRequestInvalidFilename = 600,
+    ExpressionStateRequestFileNotFound = 601,
 
-		// Errors related to InjectParameterDataRequest
-		InjectDataNoDataProvided = 450,
-		InjectDataValueInvalid = 451,
-		InjectDataWeightInvalid = 452,
-		InjectDataParamNameNotFound = 453, // Trying to send data for parameter that doesn't exist
-		InjectDataParamControlledByOtherPlugin = 454, // Only one plugin can send data for a parameter at a time
-		InjectDataModeUnknown = 455, // Only "add" and "set" can be used. If no mode is provided, "set" will be used.
+    // Errors related to ExpressionStateRequest
+    ExpressionActivationRequestInvalidFilename = 650,
+    ExpressionActivationRequestFileNotFound = 651,
+    ExpressionActivationRequestNoModelLoaded = 652,
+    
+    // Errors related to SetCurrentModelPhysicsRequest
+    SetCurrentModelPhysicsRequestNoModelLoaded = 700,
+    SetCurrentModelPhysicsRequestModelHasNoPhysics = 701,
+    SetCurrentModelPhysicsRequestPhysicsControlledByOtherPlugin = 702, 
+    SetCurrentModelPhysicsRequestNoOverridesProvided = 703,
+    SetCurrentModelPhysicsRequestPhysicsGroupIDNotFound = 704,
+    SetCurrentModelPhysicsRequestNoOverrideValueProvided = 705,
+    SetCurrentModelPhysicsRequestDuplicatePhysicsGroupID = 706,
+    
+    // Errors related to ItemLoadRequest
+    ItemFileNameMissing = 750,
+    ItemFileNameNotFound = 751,
+    ItemLoadLoadCooldownNotOver = 752, // Not used anymore. The cooldown for loading items has been removed.
+    CannotCurrentlyLoadItem = 753, // This is usually because the user has menus open that prevent items from being loaded.
+    CannotLoadItemSceneFull = 754,
+    ItemOrderInvalid = 755,
+    ItemOrderAlreadyTaken = 756,
+    ItemLoadValuesInvalid = 757, // Invalid values for fields like size, position, ...
+    ItemCustomDataInvalid = 758, // Invalid values for custom data field (customDataBase64). Happens when data is provided here but it's no valid JPG/PNG data or image dimensions are invalid.
+    ItemCustomDataLoadRequestRejectedByUser = 759, // User rejected to load the custom data item the plugin requested.
+    ItemCustomDataLoadRequestRejectedByUser = 760, // You requested a custom data image item to be loaded but the user rejected it.
+    
+    // Errors related to ItemUnloadRequest
+    CannotCurrentlyUnloadItem = 800,  // This is usually because the user has menus open that prevent items from being unloaded.
 
-		// Errors related to ParameterValueRequest
-		ParameterValueRequestParameterNotFound = 500,
+    // Errors related to ItemAnimationControlRequest
+    ItemAnimationControlInstanceIDNotFound = 850,
+    ItemAnimationControlUnsupportedItemType = 851, // Returned when trying to use this request for Live2D items.
+    ItemAnimationControlAutoStopFramesInvalid = 852, // Auto-stop frames indices have to be between 0 and the last frame index of the animated item.
+    ItemAnimationControlTooManyAutoStopFrames = 853, // Maximum allowed number per item is 1024.
+    ItemAnimationControlSimpleImageDoesNotSupportAnim = 854, // You can set stuff like transparency and brightness for normal PNG/JPG items, but nothing animation-related.
 
-		// Errors related to NDIConfigRequest
-		NDIConfigCooldownNotOver = 550,
-		NDIConfigResolutionInvalid = 551,
+    // Errors related to ItemMoveRequest
+    ItemMoveRequestInstanceIDNotFound = 900,
+    ItemMoveRequestInvalidFadeMode = 901,
+    ItemMoveRequestItemOrderTakenOrInvalid = 902,
+    ItemMoveRequestCannotCurrentlyChangeOrder = 903, // Cannot change order when any windows are open.
+    
+    // Errors related to EventSubscriptionRequest
+    EventSubscriptionRequestEventTypeUnknown = 950,
 
-		// Errors related to ExpressionStateRequest
-		ExpressionStateRequestInvalidFilename = 600,
-		ExpressionStateRequestFileNotFound = 601,
+    // Errors related to ArtMeshSelectionRequest
+    ArtMeshSelectionRequestNoModelLoaded = 1000, // Cannot start request because no model is loaded.
+    ArtMeshSelectionRequestOtherWindowsOpen = 1001, // Other windows are currently open, can't start request.
+    ArtMeshSelectionRequestModelDoesNotHaveArtMesh = 1002, // At least one of the "active" ArtMeshes you provided does not exist in the model.
+    ArtMeshSelectionRequestArtMeshIDListError = 1003, // Your "active" ArtMesh ID list is too long.
 
-		// Errors related to ExpressionStateRequest
-		ExpressionActivationRequestInvalidFilename = 650,
-		ExpressionActivationRequestFileNotFound = 651,
-		ExpressionActivationRequestNoModelLoaded = 652,
+    // Errors related to ItemPinRequest
+    ItemPinRequestGivenItemNotLoaded = 1050,
+    ItemPinRequestInvalidAngleOrSizeType = 1051,
+    ItemPinRequestModelNotFound = 1052,
+    ItemPinRequestArtMeshNotFound = 1053,
+    ItemPinRequestPinPositionInvalid = 1054,
 
-		// Errors related to SetCurrentModelPhysicsRequest
-		SetCurrentModelPhysicsRequestNoModelLoaded = 700,
-		SetCurrentModelPhysicsRequestModelHasNoPhysics = 701,
-		SetCurrentModelPhysicsRequestPhysicsControlledByOtherPlugin = 702,
-		SetCurrentModelPhysicsRequestNoOverridesProvided = 703,
-		SetCurrentModelPhysicsRequestPhysicsGroupIDNotFound = 704,
-		SetCurrentModelPhysicsRequestNoOverrideValueProvided = 705,
-		SetCurrentModelPhysicsRequestDuplicatePhysicsGroupID = 706,
+    // Errors related to PermissionRequest
+    PermissionRequestUnknownPermission = 1100,
+    PermissionRequestCannotRequestRightNow = 1101, // Permission config window is open.
+    PermissionRequestFileProblem = 1102, // Could not open or write permission file for this plugin.
+    
+    // -------------- EVENT CONFIG ERRORS --------------
+    
+    EVENT_OFFSET = 100000,
 
-		// Errors related to ItemLoadRequest
-		ItemFileNameMissing = 750,
-		ItemFileNameNotFound = 751,
-		ItemLoadLoadCooldownNotOver = 752, // Not used anymore. The cooldown for loading items has been removed.
-		CannotCurrentlyLoadItem = 753, // This is usually because the user has menus open that prevent items from being loaded.
-		CannotLoadItemSceneFull = 754,
-		ItemOrderInvalid = 755,
-		ItemOrderAlreadyTaken = 756,
-		ItemLoadValuesInvalid = 757, // Invalid values for fields like size, position, ...
+    // Event subscription errors for TestEvent
+    Event_TestEvent_TestMessageTooLong = EVENT_OFFSET + 0,
 
-		// Errors related to ItemUnloadRequest
-		CannotCurrentlyUnloadItem = 800,  // This is usually because the user has menus open that prevent items from being unloaded.
-
-		// Errors related to ItemAnimationControlRequest
-		ItemAnimationControlInstanceIDNotFound = 850,
-		ItemAnimationControlUnsupportedItemType = 851, // Returned when trying to use this request for Live2D items.
-		ItemAnimationControlAutoStopFramesInvalid = 852, // Auto-stop frames indices have to be between 0 and the last frame index of the animated item.
-		ItemAnimationControlTooManyAutoStopFrames = 853, // Maximum allowed number per item is 1024.
-		ItemAnimationControlSimpleImageDoesNotSupportAnim = 854, // You can set stuff like transparency and brightness for normal PNG/JPG items, but nothing animation-related.
-
-		// Errors related to ItemMoveRequest
-		ItemMoveRequestInstanceIDNotFound = 900,
-		ItemMoveRequestInvalidFadeMode = 901,
-		ItemMoveRequestItemOrderTakenOrInvalid = 902,
-		ItemMoveRequestCannotCurrentlyChangeOrder = 903, // Cannot change order when any windows are open.
-
-		// Errors related to EventSubscriptionRequest
-		EventSubscriptionRequestEventTypeUnknown = 950,
-
-		// -------------- EVENT CONFIG ERRORS --------------
-
-		EVENT_OFFSET = 100000,
-
-		// Event subscription errors for TestEvent
-		Event_TestEvent_TestMessageTooLong = EVENT_OFFSET + 0,
-
-		// Event subscription errors for ModelLoadedEvent
-		Event_ModelLoadedEvent_ModelIDInvalid = EVENT_OFFSET + 50
-	}
+    // Event subscription errors for ModelLoadedEvent
+    Event_ModelLoadedEvent_ModelIDInvalid = EVENT_OFFSET + 50
+}
 }

--- a/VTS/Core/Models/VTSData.cs
+++ b/VTS/Core/Models/VTSData.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.ObjectModel;
 
 namespace VTS.Core {
 
@@ -1820,6 +1821,51 @@ namespace VTS.Core {
 		End,
 	}
 
+	// Item Event
+
+	[System.Serializable]
+	public class VTSItemEventSubscriptionRequestData : VTSEventSubscriptionRequestData<VTSItemEventConfigOptions> {
+		public VTSItemEventSubscriptionRequestData() {
+			this.data.eventName = "ItemEvent";
+		}
+	}
+
+	/// <summary>
+	/// A container for providing subscription options for an Item Event subscription.
+	/// 
+	/// For more info about what each field does, see 
+	/// <a href="https://github.com/DenchiSoft/VTubeStudio/tree/master/Events#item-event">https://github.com/DenchiSoft/VTubeStudio/tree/master/Events#item-event</a>
+	/// </summary>
+	[System.Serializable]
+	public class VTSItemEventConfigOptions : VTSEventConfigData {
+		public VTSItemEventConfigOptions() { }
+
+		public VTSItemEventConfigOptions(string[] itemInstanceIDs, string[] itemFileNames) {
+			this.itemInstanceIDs = itemInstanceIDs;
+			this.itemFileNames = itemFileNames;
+		}
+
+		public string[] itemInstanceIDs;
+		public string[] itemFileNames;
+	}
+
+	[System.Serializable]
+	public class VTSItemEventData : VTSEventData {
+		public VTSItemEventData() {
+			this.messageType = "ItemEvent";
+			this.data = new Data();
+		}
+		public Data data;
+
+		[System.Serializable]
+		public class Data {
+			public VTSItemEventType itemEventType;
+			public string itemInsanceID;
+			public string itemFileName;
+			public Pair itemPosition;
+		}
+	}
+
 	[System.Serializable]
 	public enum VTSItemEventType {
 		Added,
@@ -1829,6 +1875,54 @@ namespace VTS.Core {
 		Clicked,
 		Locked,
 		Unlocked,
+	}
+
+	// Model Clicked Event
+
+	[System.Serializable]
+	public class VTSModelClickedEventSubscriptionRequestData : VTSEventSubscriptionRequestData<VTSModelClickedEventConfigOptions> {
+		public VTSModelClickedEventSubscriptionRequestData() {
+			this.data.eventName = "ModelClickedEvent";
+		}
+	}
+
+	/// <summary>
+	/// A container for providing subscription options for a Model Clicked Event subscription.
+	/// 
+	/// For more info about what each field does, see 
+	/// <a href="https://github.com/DenchiSoft/VTubeStudio/tree/master/Events#model-clicked-event">https://github.com/DenchiSoft/VTubeStudio/tree/master/Events#model-clicked-event</a>
+	/// </summary>
+	[System.Serializable]
+	public class VTSModelClickedEventConfigOptions : VTSEventConfigData {
+		public VTSModelClickedEventConfigOptions() { }
+
+		public VTSModelClickedEventConfigOptions(bool onlyClicksOnModel) {
+			this.onlyClicksOnModel = onlyClicksOnModel;
+		}
+
+		public bool onlyClicksOnModel;
+	}
+
+	[System.Serializable]
+	public class VTSModelClickedEventData : VTSEventData {
+		public VTSModelClickedEventData() {
+			this.messageType = "ModelClickedEvent";
+			this.data = new Data();
+		}
+		public Data data;
+
+		[System.Serializable]
+		public class Data {
+			public bool modelLoaded;
+			public string loadedModelID;
+			public string loadedModelName;
+			public bool modelWasClicked;
+			public int mouseButtonID;
+			public Pair clickPosition;
+			public Pair windowSize;
+			public int clickedArtMeshCount;
+			public ArtMeshHit[] artMeshHits;
+		}
 	}
 
 	[System.Serializable]

--- a/VTS/Core/Models/VTSData.cs
+++ b/VTS/Core/Models/VTSData.cs
@@ -46,6 +46,17 @@ namespace VTS.Core {
 		public float y;
 	}
 
+	[System.Serializable]
+	public enum VTSPermission {
+		LoadCustomImagesAsItems,
+	}
+
+	[System.Serializable]
+	public struct VTSPermissionStatus {
+		public VTSPermission name;
+		public bool granted;
+	}
+
 	#endregion
 
 	#region General API
@@ -82,6 +93,22 @@ namespace VTS.Core {
 			public string authenticationToken;
 			public bool authenticated;
 			public string reason;
+		}
+	}
+
+	[System.Serializable]
+	public class VTSPermissionData : VTSMessageData {
+		public VTSPermissionData() {
+			this.messageType = "PermissionRequest";
+			this.data = new Data();
+		}
+		public Data data;
+
+		[System.Serializable]
+		public class Data {
+			public bool grantSuccess;
+			public VTSPermission requestedPermission;
+			public VTSPermissionStatus[] permissions;
 		}
 	}
 

--- a/VTS/Core/Models/VTSData.cs
+++ b/VTS/Core/Models/VTSData.cs
@@ -827,6 +827,60 @@ namespace VTS.Core {
 		public bool unloadWhenPluginDisconnects;
 	}
 
+	/// <summary>
+	/// A container for holding the numerous loading options for an Custom Item Load request.
+	/// 
+	/// For more info about what each field does, see 
+	/// <a href="https://github.com/DenchiSoft/VTubeStudio#custom-data-items">https://github.com/DenchiSoft/VTubeStudio#custom-data-items</a>
+	/// </summary>
+	[System.Serializable]
+	public class VTSCustomDataItemLoadOptions : VTSItemLoadOptions {
+
+		public VTSCustomDataItemLoadOptions() : base() {
+			this.askUserFirst = true;
+			this.skipAskingUserIfWhitelisted = true;
+			this.askTimer = -1;
+		}
+
+		public VTSCustomDataItemLoadOptions(
+			float positionX,
+			float positionY,
+			float size,
+			float rotation,
+			float fadeTime,
+			int order,
+			bool failIfOrderTaken,
+			float smoothing,
+			bool censored,
+			bool flipped,
+			bool locked,
+			bool unloadWhenPluginDisconnects,
+			bool askUserFirst,
+			bool skipAskingUserIfWhitelisted,
+			float askTimer
+		) : base(
+			positionX,
+			positionY,
+			size,
+			rotation,
+			fadeTime,
+			order,
+			failIfOrderTaken,
+			smoothing,
+			censored,
+			flipped,
+			locked,
+			unloadWhenPluginDisconnects) {
+			this.askUserFirst = askUserFirst;
+			this.skipAskingUserIfWhitelisted = skipAskingUserIfWhitelisted;
+			this.askTimer = askTimer;
+		}
+
+		public bool askUserFirst;
+		public bool skipAskingUserIfWhitelisted;
+		public float askTimer;
+	}
+
 	[System.Serializable]
 	public class VTSItemLoadRequestData : VTSMessageData {
 		public VTSItemLoadRequestData() {
@@ -850,6 +904,10 @@ namespace VTS.Core {
 			public bool flipped;
 			public bool locked;
 			public bool unloadWhenPluginDisconnects;
+			public string customDataBase64;
+			public bool customDataAskUserFirst;
+			public bool customDataSkipAskingUserIfWhitelisted;
+			public float customDataAskTimer;
 		}
 	}
 

--- a/VTS/Core/Models/VTSData.cs
+++ b/VTS/Core/Models/VTSData.cs
@@ -97,8 +97,8 @@ namespace VTS.Core {
 	}
 
 	[System.Serializable]
-	public class VTSPermissionData : VTSMessageData {
-		public VTSPermissionData() {
+	public class VTSPermissionRequestData : VTSMessageData {
+		public VTSPermissionRequestData() {
 			this.messageType = "PermissionRequest";
 			this.data = new Data();
 		}
@@ -106,8 +106,21 @@ namespace VTS.Core {
 
 		[System.Serializable]
 		public class Data {
-			public bool grantSuccess;
 			public VTSPermission requestedPermission;
+		}
+	}
+
+	[System.Serializable]
+	public class VTSPermissionResponseData : VTSMessageData {
+		public VTSPermissionResponseData() {
+			this.messageType = "PermissionResponse";
+			this.data = new Data();
+		}
+		public Data data;
+
+		[System.Serializable]
+		public class Data {
+			public bool grantSuccess;
 			public VTSPermissionStatus[] permissions;
 		}
 	}
@@ -1213,6 +1226,103 @@ namespace VTS.Core {
 		}
 	}
 
+	[System.Serializable]
+	public class VTSItemPinRequestData : VTSMessageData {
+		public VTSItemPinRequestData() {
+			this.messageType = "ItemPinRequest";
+			this.data = new Data();
+		}
+		public Data data;
+
+		[System.Serializable]
+		public class Data {
+
+			public bool pin;
+			public string itemInstanceID;
+			public VTSItemAngleRelativityMode angleRelativeTo;
+			public VTSItemSizeRelativityMode sizeRealtiveTo;
+			public VTSVertexPinMode vertexPinType;
+			public ArtMeshCoordinate pinInfo;
+		}
+	}
+
+	[System.Serializable]
+	public class VTSItemPinResponseData : VTSMessageData {
+
+		public VTSItemPinResponseData() {
+			this.messageType = "ItemPinResponse";
+			this.data = new Data();
+		}
+		public Data data;
+
+		[System.Serializable]
+		public class Data {
+
+			public bool isPinned;
+			public string itemInstanceID;
+			public string itemFileName;
+		}
+	}
+
+	[System.Serializable]
+	public enum VTSItemAngleRelativityMode {
+		RelativeToWorld,
+		RelativeToCurrentItemRotation,
+		RelativeToModel,
+		RelativeToPinPosition,
+	}
+
+	[System.Serializable]
+	public enum VTSItemSizeRelativityMode {
+		RelativeToWorld,
+		RelativeToCurrentItemSize,
+	}
+
+	[System.Serializable]
+	public enum VTSVertexPinMode {
+		Provided,
+		Center,
+		Random
+	}
+
+	[System.Serializable]
+	public class ArtMeshCoordinate : BarycentricCoordinate {
+		public string modelID;
+		public string artMeshID;
+		public float angle;
+		public float size;
+
+		public BarycentricCoordinate ToBarycentricCoordinate() {
+			return new BarycentricCoordinate {
+				vertexID1 = this.vertexID1,
+				vertexID2 = this.vertexID2,
+				vertexID3 = this.vertexID3,
+				vertexWeight1 = this.vertexWeight1,
+				vertexWeight2 = this.vertexWeight2,
+				vertexWeight3 = this.vertexWeight3
+			};
+		}
+
+		public void SetBarycentricCoodrinate(BarycentricCoordinate coordinate) {
+			this.vertexID1 = coordinate.vertexID1;
+			this.vertexID2 = coordinate.vertexID2;
+			this.vertexID3 = coordinate.vertexID3;
+			this.vertexWeight1 = coordinate.vertexWeight1;
+			this.vertexWeight2 = coordinate.vertexWeight2;
+			this.vertexWeight3 = coordinate.vertexWeight3;
+		}
+	}
+
+	[System.Serializable]
+	public class BarycentricCoordinate {
+		public int vertexID1;
+		public int vertexID2;
+		public int vertexID3;
+		public float vertexWeight1;
+		public float vertexWeight2;
+		public float vertexWeight3;
+	}
+
 	#endregion
 
 	#region Event API
@@ -1650,6 +1760,24 @@ namespace VTS.Core {
 		Custom,
 		Start,
 		End,
+	}
+
+	[System.Serializable]
+	public enum VTSItemEventType {
+		Added,
+		Removed,
+		DroppedPinned,
+		DroppedUnpinned,
+		Clicked,
+		Locked,
+		Unlocked,
+	}
+
+	[System.Serializable]
+	public class ArtMeshHit {
+		public int artMeshOrder;
+		public bool isMasked;
+		public ArtMeshCoordinate hitInfo;
 	}
 
 	#endregion

--- a/VTS/Core/VTSExtensions.cs
+++ b/VTS/Core/VTSExtensions.cs
@@ -136,6 +136,27 @@ namespace VTS.Core {
 
             return tcs.Task;
         }
+
+        internal static Task<TSuccess> Async<T1, T2, T3, T4, T5, T6, T7, T8, TSuccess, TError>(
+            this Action<T1, T2, T3, T4, T5, T6, T7, T8, Action<TSuccess>, Action<TError>> action, T1 argument1, T2 argument2, T3 argument3,
+            T4 argument4, T5 argument5, T6 argument6, T7 argument7, T8 argument8) where TError : VTSErrorData {
+            var tcs = new TaskCompletionSource<TSuccess>();
+
+            action(
+                argument1,
+                argument2,
+                argument3,
+                argument4,
+                argument5,
+                argument6,
+                argument7,
+                argument8,
+                modelData => tcs.SetResult(modelData),
+                errorData => tcs.SetException(errorData.ToException())
+            );
+
+            return tcs.Task;
+        }
     }
 }
 

--- a/VTS/Core/VTSExtensions.cs
+++ b/VTS/Core/VTSExtensions.cs
@@ -79,6 +79,63 @@ namespace VTS.Core {
 
             return tcs.Task;
         }
+
+        internal static Task<TSuccess> Async<T1, T2, T3, T4, T5, TSuccess, TError>(
+            this Action<T1, T2, T3, T4, T5, Action<TSuccess>, Action<TError>> action, T1 argument1, T2 argument2, T3 argument3,
+            T4 argument4, T5 argument5) where TError : VTSErrorData {
+            var tcs = new TaskCompletionSource<TSuccess>();
+
+            action(
+                argument1,
+                argument2,
+                argument3,
+                argument4,
+                argument5,
+                modelData => tcs.SetResult(modelData),
+                errorData => tcs.SetException(errorData.ToException())
+            );
+
+            return tcs.Task;
+        }
+
+        internal static Task<TSuccess> Async<T1, T2, T3, T4, T5, T6, TSuccess, TError>(
+            this Action<T1, T2, T3, T4, T5, T6, Action<TSuccess>, Action<TError>> action, T1 argument1, T2 argument2, T3 argument3,
+            T4 argument4, T5 argument5, T6 argument6) where TError : VTSErrorData {
+            var tcs = new TaskCompletionSource<TSuccess>();
+
+            action(
+                argument1,
+                argument2,
+                argument3,
+                argument4,
+                argument5,
+                argument6,
+                modelData => tcs.SetResult(modelData),
+                errorData => tcs.SetException(errorData.ToException())
+            );
+
+            return tcs.Task;
+        }
+
+        internal static Task<TSuccess> Async<T1, T2, T3, T4, T5, T6, T7, TSuccess, TError>(
+            this Action<T1, T2, T3, T4, T5, T6, T7, Action<TSuccess>, Action<TError>> action, T1 argument1, T2 argument2, T3 argument3,
+            T4 argument4, T5 argument5, T6 argument6, T7 argument7) where TError : VTSErrorData {
+            var tcs = new TaskCompletionSource<TSuccess>();
+
+            action(
+                argument1,
+                argument2,
+                argument3,
+                argument4,
+                argument5,
+                argument6,
+                argument7,
+                modelData => tcs.SetResult(modelData),
+                errorData => tcs.SetException(errorData.ToException())
+            );
+
+            return tcs.Task;
+        }
     }
 }
 

--- a/VTS/Core/VTSWebSocket.cs
+++ b/VTS/Core/VTSWebSocket.cs
@@ -450,6 +450,9 @@ namespace VTS.Core {
 									case "PermissionResponse":
 										this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSPermissionResponseData>(data));
 										break;
+									case "ItemPinResponse":
+										this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSItemPinResponseData>(data));
+										break;
 									case "EventSubscriptionResponse":
 										this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSEventSubscriptionResponseData>(data));
 										break;

--- a/VTS/Core/VTSWebSocket.cs
+++ b/VTS/Core/VTSWebSocket.cs
@@ -338,6 +338,12 @@ namespace VTS.Core {
 									case "ModelAnimationEvent":
 										this._events[response.messageType].onEvent(this._json.FromJson<VTSModelAnimationEventData>(data));
 										break;
+									case "ItemEvent":
+										this._events[response.messageType].onEvent(this._json.FromJson<VTSItemEventData>(data));
+										break;
+									case "ModelClickedEvent":
+										this._events[response.messageType].onEvent(this._json.FromJson<VTSModelClickedEventData>(data));
+										break;
 								}
 							} catch (Exception e) {
 								// Neatly handle errors in case the deserialization or success callback throw an exception
@@ -461,7 +467,6 @@ namespace VTS.Core {
 										error.data.message = "Unable to parse response as valid response type: " + data;
 										this._callbacks[response.requestID].onError(error);
 										break;
-
 								}
 							} catch (Exception e) {
 								// Neatly handle errors in case the deserialization or success callback throw an exception

--- a/VTS/Core/VTSWebSocket.cs
+++ b/VTS/Core/VTSWebSocket.cs
@@ -447,6 +447,9 @@ namespace VTS.Core {
 									case "ArtMeshSelectionResponse":
 										this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSArtMeshSelectionResponseData>(data));
 										break;
+									case "PermissionResponse":
+										this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSPermissionResponseData>(data));
+										break;
 									case "EventSubscriptionResponse":
 										this._callbacks[response.requestID].onSuccess(this._json.FromJson<VTSEventSubscriptionResponseData>(data));
 										break;

--- a/VTS/Unity/UnityVTSPlugin.cs
+++ b/VTS/Unity/UnityVTSPlugin.cs
@@ -213,6 +213,10 @@ namespace VTS.Unity {
 			this.Plugin.LoadItem(fileName, options, onSuccess, onError);
 		}
 
+		public void LoadCustomDataItem(string fileName, string base64, VTSCustomDataItemLoadOptions options, Action<VTSItemLoadResponseData> onSuccess, Action<VTSErrorData> onError) {
+			this.Plugin.LoadCustomDataItem(fileName, base64, options, onSuccess, onError);
+		}
+
 		public void UnloadItem(VTSItemUnloadOptions options, Action<VTSItemUnloadResponseData> onSuccess, Action<VTSErrorData> onError) {
 			this.Plugin.UnloadItem(options, onSuccess, onError);
 		}
@@ -232,7 +236,22 @@ namespace VTS.Unity {
 		}
 
 		public void RequestPermission(VTSPermission permission, Action<VTSPermissionResponseData> onSuccess, Action<VTSErrorData> onError) {
-			Plugin.RequestPermission(permission, onSuccess, onError);
+			this.Plugin.RequestPermission(permission, onSuccess, onError);
+		}
+
+		public void PinItemToCenter(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError) {
+			this.Plugin.PinItemToCenter(itemInstanceID, modelID, artMeshID, angle, angleRelativeTo, size, sizeRelativeTo, onSuccess, onError);
+		}
+
+		public void PinItemToRandom(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError) {
+			this.Plugin.PinItemToRandom(itemInstanceID, modelID, artMeshID, angle, angleRelativeTo, size, sizeRelativeTo, onSuccess, onError);
+		}
+		public void PinItemToPoint(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo, BarycentricCoordinate point, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError) {
+			this.Plugin.PinItemToPoint(itemInstanceID, modelID, artMeshID, angle, angleRelativeTo, size, sizeRelativeTo, point, onSuccess, onError);
+		}
+
+		public void UnpinItem(string itemInsanceID, Action<VTSItemPinResponseData> onSuccess, Action<VTSErrorData> onError) {
+			this.Plugin.UnpinItem(itemInsanceID, onSuccess, onError);
 		}
 
 		#endregion
@@ -407,6 +426,10 @@ namespace VTS.Unity {
 			return this.Plugin.LoadItem(fileName, options);
 		}
 
+		public Task<VTSItemLoadResponseData> LoadCustomDataItem(string fileName, string base64, VTSCustomDataItemLoadOptions options) {
+			return this.Plugin.LoadCustomDataItem(fileName, base64, options);
+		}
+
 		public Task<VTSModelLoadData> LoadModel(string modelId) {
 			return this.Plugin.LoadModel(modelId);
 		}
@@ -428,7 +451,23 @@ namespace VTS.Unity {
 		}
 
 		public Task<VTSPermissionResponseData> RequestPermission(VTSPermission permission) {
-			return Plugin.RequestPermission(permission);
+			return this.Plugin.RequestPermission(permission);
+		}
+
+		public Task<VTSItemPinResponseData> PinItemToCenter(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo) {
+			return this.Plugin.PinItemToCenter(itemInstanceID, modelID, artMeshID, angle, angleRelativeTo, size, sizeRelativeTo);
+		}
+
+		public Task<VTSItemPinResponseData> PinItemToRandom(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo) {
+			return this.Plugin.PinItemToRandom(itemInstanceID, modelID, artMeshID, angle, angleRelativeTo, size, sizeRelativeTo);
+		}
+
+		public Task<VTSItemPinResponseData> PinItemToPoint(string itemInstanceID, string modelID, string artMeshID, float angle, VTSItemAngleRelativityMode angleRelativeTo, float size, VTSItemSizeRelativityMode sizeRelativeTo, BarycentricCoordinate point) {
+			return this.Plugin.PinItemToPoint(itemInstanceID, modelID, artMeshID, angle, angleRelativeTo, size, sizeRelativeTo, point);
+		}
+
+		public Task<VTSItemPinResponseData> UnpinItem(string itemInstanceID) {
+			return this.Plugin.UnpinItem(itemInstanceID);
 		}
 
 		public Task<VTSOverrideModelPhysicsData> SetCurrentModelPhysics(VTSPhysicsOverride[] strengthOverrides, VTSPhysicsOverride[] windOverrides) {

--- a/VTS/Unity/UnityVTSPlugin.cs
+++ b/VTS/Unity/UnityVTSPlugin.cs
@@ -334,6 +334,22 @@ namespace VTS.Unity {
 			this.Plugin.UnsubscribeFromModelAnimationEvent(onUnsubscribe, onError);
 		}
 
+		public void SubscribeToItemEvent(VTSItemEventConfigOptions config, Action<VTSItemEventData> onEvent, Action<VTSEventSubscriptionResponseData> onSubscribe, Action<VTSErrorData> onError) {
+			this.Plugin.SubscribeToItemEvent(config, onEvent, onSubscribe, onError);
+		}
+
+		public void UnsubscribeFromItemEvent(Action<VTSEventSubscriptionResponseData> onUnsubscribe, Action<VTSErrorData> onError) {
+			this.Plugin.UnsubscribeFromItemEvent(onUnsubscribe, onError);
+		}
+
+		public void SubscribeToModelClickedEvent(VTSModelClickedEventConfigOptions config, Action<VTSModelClickedEventData> onEvent, Action<VTSEventSubscriptionResponseData> onSubscribe, Action<VTSErrorData> onError) {
+			this.Plugin.SubscribeToModelClickedEvent(config, onEvent, onSubscribe, onError);
+		}
+
+		public void UnsubscribeFromModelClickedEvent(Action<VTSEventSubscriptionResponseData> onUnsubscribe, Action<VTSErrorData> onError) {
+			this.Plugin.UnsubscribeFromModelClickedEvent(onUnsubscribe, onError);
+		}
+
 		#endregion
 
 		#region Async/Await Wrappers
@@ -518,6 +534,14 @@ namespace VTS.Unity {
 			return this.Plugin.SubscribeToTrackingEvent(onEvent);
 		}
 
+		public Task<VTSEventSubscriptionResponseData> SubscribeToItemEvent(VTSItemEventConfigOptions config, Action<VTSItemEventData> onEvent) {
+			return this.Plugin.SubscribeToItemEvent(config, onEvent);
+		}
+
+		public Task<VTSEventSubscriptionResponseData> SubscribeToModelClickedEvent(VTSModelClickedEventConfigOptions config, Action<VTSModelClickedEventData> onEvent) {
+			return this.Plugin.SubscribeToModelClickedEvent(config, onEvent);
+		}
+
 		public Task<VTSColorTintData> TintArtMesh(ColorTint tint, float mixWithSceneLightingColor, ArtMeshMatcher matcher) {
 			return this.Plugin.TintArtMesh(tint, mixWithSceneLightingColor, matcher);
 		}
@@ -572,6 +596,14 @@ namespace VTS.Unity {
 
 		public Task<VTSEventSubscriptionResponseData> UnsubscribeFromModelAnimationEvent() {
 			return this.Plugin.UnsubscribeFromModelAnimationEvent();
+		}
+
+		public Task<VTSEventSubscriptionResponseData> UnsubscribeFromItemEvent() {
+			return this.Plugin.UnsubscribeFromItemEvent();
+		}
+
+		public Task<VTSEventSubscriptionResponseData> UnsubscribeFromModelClickedEvent() {
+			return this.Plugin.UnsubscribeFromModelClickedEvent();
 		}
 
 		#endregion

--- a/VTS/Unity/UnityVTSPlugin.cs
+++ b/VTS/Unity/UnityVTSPlugin.cs
@@ -231,6 +231,10 @@ namespace VTS.Unity {
 			this.Plugin.RequestArtMeshSelection(textOverride, helpOverride, count, activeArtMeshes, onSuccess, onError);
 		}
 
+		public void RequestPermission(VTSPermission permission, Action<VTSPermissionResponseData> onSuccess, Action<VTSErrorData> onError) {
+			Plugin.RequestPermission(permission, onSuccess, onError);
+		}
+
 		#endregion
 
 		#region VTS Event Subscription API Wrapper
@@ -421,6 +425,10 @@ namespace VTS.Unity {
 
 		public Task<VTSArtMeshSelectionResponseData> RequestArtMeshSelection(string textOverride, string helpOverride, int count, ICollection<string> activeArtMeshes) {
 			return this.Plugin.RequestArtMeshSelection(textOverride, helpOverride, count, activeArtMeshes);
+		}
+
+		public Task<VTSPermissionResponseData> RequestPermission(VTSPermission permission) {
+			return Plugin.RequestPermission(permission);
 		}
 
 		public Task<VTSOverrideModelPhysicsData> SetCurrentModelPhysics(VTSPhysicsOverride[] strengthOverrides, VTSPhysicsOverride[] windOverrides) {


### PR DESCRIPTION
This pull request adds:

- `ItemPinRequest` methods, with variants to pin items to the center, to a random position, and to a specific position on an ArtMesh.
- `LoadCustomDataItem` method, which allows the user to load an item via a base64 string.
- `PermissionRequest` method, to request permission to use the aforementioned Custom Data Item method.
-  `SubscribeToItemEvent` and `UnsubscribeFromItemEvent` methods.
- `SubscribeToModelClickedEvent` and `UnsubscribeFromModelClickedEvent` methods.

All of the above also have `async` variants.