### PR TITLE
fix: implement VTS port discovery UDP socket timeout

### DIFF
--- a/VTS/Core/CoreVTSPlugin.cs
+++ b/VTS/Core/CoreVTSPlugin.cs
@@ -58,6 +58,7 @@ namespace VTS.Core {
 		public void Dispose() {
 			this.Logger.Log(string.Format("Disposing of VTS Plugin: {0}...", this.PluginName));
 			this._cancelToken.Cancel();
+			this.Socket.Dispose();
 		}
 
 		#region Initialization


### PR DESCRIPTION
I'm writing a "soft restart" feature for my app which uses VTS-Sharp so I need to destroy objects not only on shutdown but on-demand as well, so my use case is a bit more sensitive to leaks.

That's when I noticed lingering Tasks even after disposal of the `CoreVTSPlugin`; investigation led me to this `ReceiveAsync` call:

https://github.com/FomTarro/VTS-Sharp/blob/d9fd55e5c4147656be69187088cd9ebb7c91937d/VTS/Core/VTSWebSocket.cs#L119

This blocks and never returns if the UDP socket doesn't receive packets (e.g., when VTS is not running).

This PR:
1. Chains the UDP Port Discovery `UdpClient` disposal with `VTSWebSocket.Dispose` then `CoreVTSPlugin.Dispose`
2. Sets a receive timeout on the UDP Port Discovery `UdpClient` to 2 times the default discovery timeout.
3. Use the sync version of `Receive` and wrap it around a Task such that it is backward-compatible with the existing code. This is required because the async version does not respect the receive timeout, which is why 2 alone is not enough.